### PR TITLE
Sync release notes from forum

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+# This is a basic workflow to help you get started with Actions
+
+name: sync-release-notes-from-forum
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  schedule:
+  - cron: "0 0/6 * * *"
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+    
+    - uses: actions/setup-python@v2
+    
+    - name: Setup & Check enviroment
+      run: |
+        pwd
+        python --version
+        pip install -U requests html2markdown
+    # Runs a single command using the runners shell
+    - name: Run the script
+      run: python .scripts/fetch_forum_release_notes.py
+
+    - name: Show diff
+      run: git diff
+      
+    - name: Add & Commit
+      uses: EndBug/add-and-commit@v4.2.1

--- a/.scripts/fetch_forum_release_notes.py
+++ b/.scripts/fetch_forum_release_notes.py
@@ -1,0 +1,30 @@
+import re
+import glob
+import requests
+import html2markdown
+
+# Config
+forum_announce_url = "https://forum.obsidian.md/c/announcements/13"
+target_folder = "Release notes"
+
+def fourm_post_content_md(url:str) -> str:
+    post_page = requests.get(url).text
+    post_content = re.findall("<div class='post'.*?>(.*?)</div>",release_note_page, re.S)[0]
+    return html2markdown.convert(release_note_content)
+    
+# main
+forum_announce_page = requests.get(forum_announce_url).text
+forum_announce_list = re.findall("<a href='(.*?)'.*?>Obsidian Release (.*?)</a>",forum_announce_page)
+
+existing_releases:list = [ x[len(target_folder)+1:-3] for x in glob.glob(target_folder+"/*.md")]
+
+for each in forum_announce_list:
+    version = each[1].replace(" (Insider build)","")
+    if version in existing_releases: continue
+    
+    release_content = fourm_post_content_md(each[0])
+    release_filename = ''.join([target_folder,'/',version,'.md'])
+    print(release_filename)
+    print(release_content)
+    with open(release_filename,'w') as f:
+        f.write(release_content)


### PR DESCRIPTION
Sync release notes from forum posts to the git repo via GitHub Actions. 

Here the sync job is set to run 4 times a day but feel free to change the frequency.