### PR TITLE
Add missing word to Workspaces page

### DIFF
--- a/en/Plugins/Workspaces.md
+++ b/en/Plugins/Workspaces.md
@@ -7,7 +7,7 @@ The Workspaces plugin lets you save and load "workspaces". Each workspace includ
 
 Either click on the workspace icon in the ribbon to open "Manage workspaces".
 
-Give the current layout a new, click on "Save", and it will appear in the list below.
+Give the current layout a new name, click on "Save", and it will appear in the list below.
 
 ### Load a workspace
 


### PR DESCRIPTION
I noticed a word was missing in the doc pages for the Workspaces plugin.

(I didn't edit the second edit that GitHub shows, I think that is a whitespace change.)