### PR TITLE
Typo correction in Contributing to Obsidian.md

### DIFF
--- a/en/Advanced topics/Contributing to Obsidian.md
+++ b/en/Advanced topics/Contributing to Obsidian.md
@@ -38,7 +38,7 @@ If you're a JavaScript/TypeScript programmer, you can write [[Third-party plugin
 
 #### Translating the interface
 
-If you know another language (preferably natively), you can help with translating the Obsidian interface into your language. You an do that by submitting a pull request in [our translation GitHub repository](https://github.com/obsidianmd/obsidian-translations) to get it into the next version of the app.
+If you know another language (preferably natively), you can help with translating the Obsidian interface into your language. You can do that by submitting a pull request in [our translation GitHub repository](https://github.com/obsidianmd/obsidian-translations) to get it into the next version of the app.
 
 #### Translating the docs
 


### PR DESCRIPTION
Missing a "c" on the word "can" under Translating the interface - added it in. 

Ironically, I came to fork and pull request a different typo - my recently downloaded Obsidian program shows "doesn't" instead of "don't" under Translating the docs, although it's corrected in the main here. 

Is there a roving typo-maker conducting social engineering to engage nitpicky proofreaders? :D If so - it's working!