### PR TITLE
en/ru: index updated with help-ru

### DIFF
--- a/en/Obsidian/Credits.md
+++ b/en/Obsidian/Credits.md
@@ -30,7 +30,7 @@ Names are not listed by amount of contribution, but alphabetically (or at least 
 - canzi-teacher, 蚕子 (Chinese Simplified)
 - Daniel Mathiot (French)
 - Henrik Falk (Danish)
-- Jxhnny Ut8h (Russian) 
+- JxhnnyUt8h (Russian) 
 - k-andzhanovskii, Константин Анджановский (Russian)
 - lisachev, Сергей Лисачев (Russian)
 - mafsi, (Patrick Danilevici) (Română)

--- a/en/Obsidian/Index.md
+++ b/en/Obsidian/Index.md
@@ -13,6 +13,7 @@ This help site is also available in other languages:
 - [中文](https://publish.obsidian.md/help-zh)
 - [日本語](https://publish.obsidian.md/help-ja)
 - [Dansk](https://publish.obsidian.md/help-da)
+- [Русский](https://publish.obsidian.md/help-ru)
 
 ## Credits
 
@@ -48,12 +49,3 @@ To read more about the makers, see the [about page](https://obsidian.md/about) o
 - [[Working with multiple vaults]]
 - [[Working with multiple cursors]]
 - [[Using obsidian URI]]
-
-### Other languages
-
-This published help site is also available in:
-
-- [Dansk](https://publish.obsidian.md/help-da)
-- [Italiano](https://publish.obsidian.md/help-it)
-- [中文](https://publish.obsidian.md/help-zh)
-- [日本語](https://publish.obsidian.md/help-ja)

--- a/ru/Obsidian/Указатель.md
+++ b/ru/Obsidian/Указатель.md
@@ -2,7 +2,7 @@
 
 Добро пожаловать в хранилище официальной документации Obsidian! Эта страница содержит краткий указатель вещей, которые могут вас заинтересовать.
 
-Ознакомиться с веб-версией: https://publish.obsidian.md/help %%must be requested for help-ru%%
+Ознакомиться с веб-версией: https://publish.obsidian.md/help-ru
 
 Если вы обнаружили ошибки или недостающую информацию, вы можете внести свой вклад в работу этого сайта здесь: https://github.com/obsidianmd/obsidian-docs/
 
@@ -10,6 +10,7 @@
 
 Эта публичная Справка также доступна на следующих языках:
 
+- [English](https://publish.obsidian.md/help)
 - [Italiano](https://publish.obsidian.md/help-it)
 - [中文](https://publish.obsidian.md/help-zh)
 - [日本語](https://publish.obsidian.md/help-ja)


### PR DESCRIPTION
en/ru: Index file updated with new help-ru link. Proposed to remove duplicate of 'Other languages' section.