### PR TITLE
add proxy instructions for vercel

### DIFF
--- a/en/Licenses & add-on services/Obsidian Publish.md
+++ b/en/Licenses & add-on services/Obsidian Publish.md
@@ -107,7 +107,7 @@ Once you create the page rule, you should also create a CNAME record for `www.my
 
 If you wish to host your own web server and setup your own SSL encryption, you can choose this option. If you are already hosting a website under your domain or subdomain, you can also use this option and setup your website to load your Obsidian Publish site under a specific URL path, instead of hosting the full site.
 
-Simply proxy all requests under that URL path to `https://publish.obsidian.md/serve?url=mysite.com/my-subpath/...` and configure the site options in Obsidian to the same URL path.
+Simply proxy all requests under that URL path to `https://publish.obsidian.md/serve?url=mysite.com/my-notes/...` and **configure the site options in Obsidian to the same URL path** by setting **Custom URL** to `mysite.com/my-notes`.
 
 For example, in NGINX, you can set it up as:
 ```nginx

--- a/en/Licenses & add-on services/Obsidian Publish.md
+++ b/en/Licenses & add-on services/Obsidian Publish.md
@@ -109,7 +109,7 @@ If you wish to host your own web server and setup your own SSL encryption, you c
 
 Simply proxy all requests under that URL path to `https://publish.obsidian.md/serve?url=mysite.com/my-notes/...` and **configure the site options in Obsidian to the same URL path** by setting **Custom URL** to `mysite.com/my-notes`.
 
-For example, in NGINX, you can set it up as:
+##### NGINX
 ```nginx
 location /my-notes {
   proxy_pass https://publish.obsidian.md/serve?url=mysite.com/my-notes/;
@@ -117,14 +117,15 @@ location /my-notes {
 }
 ```
 
-In Apache `.htaccess`, you can set it up as:
-(Note: mod_rewrite must be enabled, and you may also need to configure [SSLProxyEngine](https://stackoverflow.com/questions/40938148/reverse-proxy-for-external-url-apache))
+##### Apache
+Add to `.htaccess`
 ```htaccess
 RewriteEngine  on
 RewriteRule    "^my-notes/(.*)$"  "https://publish.obsidian.md/serve?url=mysite.com/my-notes/$1"  [L,P]
 ```
+Note: mod_rewrite must be enabled, and you may also need to configure [SSLProxyEngine](https://stackoverflow.com/questions/40938148/reverse-proxy-for-external-url-apache)
 
-If you're using Netlify, you can set it up as:
+##### Netlify
 ```
 [[redirects]]
   from = "https://mysite.com/my-notes/*"
@@ -133,6 +134,26 @@ If you're using Netlify, you can set it up as:
   force = true
 ```
 
+##### Vercel
+In `vercel.json` [configure rewrites](https://vercel.com/docs/configuration#project/rewrites).
+```json
+{
+  ...
+
+  "rewrites": [
+    {
+      "source": "/my-notes/",
+      "destination": "https://publish.obsidian.md/serve?url=mysite.com/my-notes"
+    },
+    {
+      "source": "/my-notes/:path*",
+      "destination": "https://publish.obsidian.md/serve?url=mysite.com/my-notes/:path*"
+    }
+  ]
+}
+```
+
+##### Supported HTTP X-Headers
 Alternatively, if your proxy service does not allow query paths, you can use `https://publish.obsidian.md/` with a custom header `x-obsidian-custom-domain` set to your site url `mysite.com/my-subpath`.
 
 #### Custom domain post-setup issues


### PR DESCRIPTION
Add instructions for URL re-writing to proxy obsidian publish on a personal site.
Vercel has a quirk in that it requires an explicit re-write for the root path.