### PR TITLE
Update outdated navigation tips

### DIFF
--- a/en/Advanced topics/Deleting files.md
+++ b/en/Advanced topics/Deleting files.md
@@ -4,4 +4,4 @@ Obsidian has several options for dealing with deleted files, depending on your n
 - Deleted files can be sent to a special `.trash` directory in your Vault. This can be useful if you want the ability to recover your Vault files separate from your system trash. 
 - You can also set obsidian to just delete files without possibility of recovery. 
 
-These options can be found in Settings => File.
+These options can be found in Settings => Files & Links.

--- a/en/Advanced topics/Third-party plugins.md
+++ b/en/Advanced topics/Third-party plugins.md
@@ -18,15 +18,15 @@ By default, Obsidian has Safe Mode turned on to protect you from potential harm.
 
 Please be aware that third-party plugins can access files on your computer, connect to the internet, and even install additional programs. To read more about plugin security, [[#Plugin security|see here]].
 
-In order to install third-party plugins, you need to turn off Safe Mode in Settings -> Community plugins -> Safe mode.
+In order to install third-party plugins, you need to turn off Safe Mode in Settings => Community plugins => Safe mode.
 
 #### Discover and install community plugins
 
-After disabling Safe Mode, you can find third-party plugins created by the community in Settings -> Community plugins -> Browse.
+After disabling Safe Mode, you can find third-party plugins created by the community in Settings => Community plugins => Browse.
 
 On this page, you can browse plugins by popularity, or search for specific plugins. Click on a plugin to see details and instruction from the plugin author. In the details page, you can click "Install" to install a plugin.
 
-After installing, you can then find the installed plugins under Settings -> Community plugins. They need to be enabled in order to take effect. You can also uninstall them there.
+After installing, you can then find the installed plugins under Settings => Community plugins. They need to be enabled in order to take effect. You can also uninstall them there.
 
 ### Plugin security
 

--- a/en/Advanced topics/Third-party plugins.md
+++ b/en/Advanced topics/Third-party plugins.md
@@ -18,15 +18,15 @@ By default, Obsidian has Safe Mode turned on to protect you from potential harm.
 
 Please be aware that third-party plugins can access files on your computer, connect to the internet, and even install additional programs. To read more about plugin security, [[#Plugin security|see here]].
 
-In order to install third-party plugins, you need to turn off Safe Mode in Settings -> Third-party plugin -> Safe Mode.
+In order to install third-party plugins, you need to turn off Safe Mode in Settings -> Community plugins -> Safe mode.
 
 #### Discover and install community plugins
 
-After disabling Safe Mode, you can find third-party plugins created by the community in Settings -> Third-party plugin -> Community plugins -> Browse.
+After disabling Safe Mode, you can find third-party plugins created by the community in Settings -> Community plugins -> Browse.
 
 On this page, you can browse plugins by popularity, or search for specific plugins. Click on a plugin to see details and instruction from the plugin author. In the details page, you can click "Install" to install a plugin.
 
-After installing, you can then find the installed plugins under Settings -> Third-party plugin. They need to be enabled in order to take effect. You can also uninstall them there.
+After installing, you can then find the installed plugins under Settings -> Community plugins. They need to be enabled in order to take effect. You can also uninstall them there.
 
 ### Plugin security
 

--- a/en/Attachments/Slides demo.md
+++ b/en/Attachments/Slides demo.md
@@ -1,7 +1,7 @@
 ## Obsidian slides demo
 
 To view slides, you'll need to enable the "Slides" plugin.
-This can be done through the "Settings" button on the bottom left.
+This can be done through the Settings => Core plugins.
 
 ---
 

--- a/en/Customization/Custom hotkeys.md
+++ b/en/Customization/Custom hotkeys.md
@@ -10,4 +10,4 @@ The fastest way to see the hotkey set for a command is to find the command in [[
 
 ### Setting hotkeys
 
-To add a hotkey, remove a hotkey, or restore hotkeys to default, go to Settings - Hotkeys. Note that you can also filter the list, as the list of commands is quite long.
+To add a hotkey, remove a hotkey, or restore hotkeys to default, go to Settings => Hotkeys. Note that you can also filter the list, as the list of commands is quite long.

--- a/en/How to/Add custom styles.md
+++ b/en/How to/Add custom styles.md
@@ -6,20 +6,20 @@ When you want to add custom styles to your vault, there are two main ways to do 
 
 Themes allow you to toggle the appearance of your vault with a dropdown menu once they have been added to your vault's theme directory.
 
-This configuration can be found in `Settings` > `Appearance` > `Themes` section of your vault settings.
+This configuration can be found in `Settings` => `Appearance` => `Themes` section of your vault settings.
 
 ### Create a custom theme
 
 If you are creating your own theme, you can do this by:
 
 1. Creating your custom theme CSS file in the themes directory `YOUR_VAULT/.obsidian/themes/YOUR_CUSTOM_THEME.css`
-2. Enabling it in the theme dropdown under `Settings` > `Appearance` > `Themes`
+2. Enabling it in the theme dropdown under `Settings` => `Appearance` => `Themes`
 
 For more information on how to customize styles of the graph, you can find more information in [[Graph view]].
 
 ### Use Themes and/or CSS snippets
 
-You can find this configuration under Appearance in the settings. You can choose a community theme or set the theme you developed yourself. If you set a community theme, it will be automatically placed in the correct folder. If you develop your own theme, you have to put it in the shown folder location yourself.
+You can find this configuration in `Settings` => `Appearance`. You can choose a community theme or set the theme you developed yourself. If you set a community theme, it will be automatically placed in the correct folder. If you develop your own theme, you have to put it in the shown folder location yourself.
 
 CSS snippets are supposed to be small pieces of CSS for small changes you want to make/things you want to add. These snippets have to be placed in the shown directory.
 

--- a/en/How to/Folding.md
+++ b/en/How to/Folding.md
@@ -1,6 +1,6 @@
 Folding text is an extremely powerful tool for outlining or writing, in order to focus on what you're working on. 
 
-To use folding, go to Settings (the gear icon on the left) and turn on `Fold indent` and `Fold heading` in the editor settings.
+To use folding, go to Settings (the gear icon on the left) => Editor and turn on `Fold indent` and `Fold heading`.
 
 Obsidian has the ability to fold both markdown headers and indented lists. Note that at the top of this note there is a downward pointing arrow next to the title. If clicked, it will fold the entire note up, and if clicked again, it will show the note. This can be applied at multiple levels of markdown, as well as multiple levels of indentation in lists.
 

--- a/en/How to/Manage attachments.md
+++ b/en/How to/Manage attachments.md
@@ -28,7 +28,7 @@ You can also download images from your browser into your vault folder directly f
 
 ## Change default attachment location
 
-By default, new attachments will be dropped in the root of your vault. You can fine tune this setting in Settings -> Files & Links -> "Default location for new attachments".
+By default, new attachments will be dropped in the root of your vault. You can fine tune this setting in Settings => Files & Links -> "Default location for new attachments".
 
 ### Choose a folder
 

--- a/en/How to/Manage attachments.md
+++ b/en/How to/Manage attachments.md
@@ -28,7 +28,7 @@ You can also download images from your browser into your vault folder directly f
 
 ## Change default attachment location
 
-By default, new attachments will be dropped in the root of your vault. You can fine tune this setting in Settings => Files & Links -> "Default location for new attachments".
+By default, new attachments will be dropped in the root of your vault. You can fine tune this setting in Settings => Files & Links => "Default location for new attachments".
 
 ### Choose a folder
 

--- a/en/How to/Update Obsidian.md
+++ b/en/How to/Update Obsidian.md
@@ -2,7 +2,7 @@
 
 Obsidian checks for update every 12 hours. Once an update is available, restarting the app will automatically bring you to the latest version.
 
-You can check your current version, check for updates in Settings -> About. You can also turn off "automatic updates" there.
+You can check your current version, check for updates in Settings => About. You can also turn off "automatic updates" there.
 
 ### Insider build
 
@@ -10,7 +10,7 @@ If you're looking to update to the latest insider build, please refer to [[Insid
 
 ### Current version vs installed version
 
-If you look closely in Settings -> About, you can find your current version and your installer version.
+If you look closely in Settings => About, you can find your current version and your installer version.
 
 Your current version is your Obsidian version. This is the version of the app on top of the engine (which is Electron). It will increase when you auto-update, but your installer version will not. Your installer version will only increase when you install Obsidian with a new installer.
 

--- a/en/Licenses & add-on services/Obsidian Sync.md
+++ b/en/Licenses & add-on services/Obsidian Sync.md
@@ -24,7 +24,7 @@ In the future, we'll improve Obsidian Sync with:
 
 ### Enable Obsidian Sync plugin
 
-You can enable Obsidian Sync by enabling the "Sync" plugin under Settings -> Core plugins.
+You can enable Obsidian Sync by enabling the "Sync" plugin under Settings => Core plugins.
 
 ### Setting up remote vaults
 
@@ -72,13 +72,13 @@ You can selectively sync files by folder or file type. ==Selective sync only app
 
 ##### Exclude folders
 
-You can uncheck folders in Settings -> Sync -> Excluded folders -> Manage to prevent them from getting synced.
+You can uncheck folders in Settings => Sync => Excluded folders => Manage to prevent them from getting synced.
 
 Excluded folders will be ignored when both uploading and download changes.
 
 #### File types
 
-You can toggle sync for images, audio, video, PDFs, and unsupported files under Settings -> Sync -> Selective sync.
+You can toggle sync for images, audio, video, PDFs, and unsupported files under Settings => Sync => Selective sync.
 
 ### Synchronizing settings
 
@@ -173,4 +173,4 @@ Here are the technical details for those interested:
 
 Each vault using Obsidian Sync has a maximum size of 4gb. This error indicates your vault has exceeded that limit in size. Don't forget: attachments and version history contributes to the maximum, so you may exceed your 4gb limit even if your vault's actual size is less than 4gb. 
 
-If you see this error, Obsidian can help you identify and purge large files from the Vault. Go to the Obsidian Sync settings in Preferences → Sync and look for the "Vault size over limit" options. 
+If you see this error, Obsidian can help you identify and purge large files from the Vault. Go to the Obsidian Sync settings in Preferences => Sync and look for the "Vault size over limit" options. 

--- a/en/Licenses & add-on services/Obsidian Sync.md
+++ b/en/Licenses & add-on services/Obsidian Sync.md
@@ -32,7 +32,7 @@ Warning: We do not recommend using third party sync services to sync the same va
 
 To start syncing, first you need to create a remote vault that stores your encrypted data.
 
-To do that, go to Setting -> Sync -> Pick remote vault -> Choose -> Create new vault.
+To do that, go to Setting => Sync => Pick remote vault => Choose => Create new vault.
 
 After creating it, you can immediately connect to the vault by clicking on the "Connect" button next to it.
 
@@ -62,7 +62,7 @@ After selecting a version in the left column in the version history screen, you 
 
 ### Deleted files
 
-After you delete a file, you can view it in Setting -> Sync -> Deleted files -> View.
+After you delete a file, you can view it in Setting => Sync => Deleted files => View.
 
 Clicking on a deleted file will open its version history. You can then choose to restore the file back to a previous version.
 

--- a/en/Plugins/Command palette.md
+++ b/en/Plugins/Command palette.md
@@ -1,6 +1,6 @@
 The Command Palette is enabled by default, as it is a very useful way to access nearly all the features of Obsidian without having to remember key strokes. Type `Ctrl/Cmd+P` to activate, then simply type in the name of the command. If a command has a hotkey, it will appear in on the right side.
 
-Custom shorcuts can be added to the Command Palette in Settings -> Keymap. Click on the `*` icon to the right of each key listed and type whatever key combination you would like.
+Custom shorcuts can be added to the Command Palette in Settings => Hotkeys. Click on the `*` icon to the right of each key listed and type whatever key combination you would like.
 
 ### Settings
 

--- a/en/Plugins/Publish.md
+++ b/en/Plugins/Publish.md
@@ -4,7 +4,7 @@ For more information about the Obsidian Publish™ service, what's included, how
 
 ### Enable the plugin
 
-From within Obsidian > Settings > Plugin, enable the Publish plugin. After that, a Publish icon (which looks like a paper plane) will appear in the ribbon pane.
+From within Obsidian => Settings => Plugin, enable the Publish plugin. After that, a Publish icon (which looks like a paper plane) will appear in the ribbon pane.
 
 Once enabled, you can also set a hotkey for this option, or use the command palette to access it.
 

--- a/en/Plugins/Search.md
+++ b/en/Plugins/Search.md
@@ -6,7 +6,7 @@ Search is a powerful feature, and has the potential to be confusing. In most cas
 
 ### Start searching
 
-You can invoke search by pressing `Ctrl-Shift-F` or `Cmd-Shift-F`. You can also customize this hotkey in Settings -> Hotkeys. When search is invoked, focus will be automatically put in the search bar so you can start typing your query right away.
+You can invoke search by pressing `Ctrl-Shift-F` or `Cmd-Shift-F`. You can also customize this hotkey in Settings => Hotkeys. When search is invoked, focus will be automatically put in the search bar so you can start typing your query right away.
 
 ### Search selected text
 

--- a/en/Plugins/Templates.md
+++ b/en/Plugins/Templates.md
@@ -4,7 +4,7 @@ The Templates plugin lets you quickly insert snippets of text into your current 
 
 Each template snippet is just a normal Markdown note, like everything else in Obsidian.
 
-To designate template files, put them into a folder, and choose that folder in Settings -> Templates -> "Template folder location" after enabling the plugin
+To designate template files, put them into a folder, and choose that folder in Settings => Templates => "Template folder location" after enabling the plugin
 
 ### Insert a template
 

--- a/en/Start here.md
+++ b/en/Start here.md
@@ -30,13 +30,13 @@ Here are a few ways to get started:
 
 If you want to just start taking notes, check out [[Basic note taking]]
 
-If you already have a collection of notes in markdown format, just choose them for your Vault. Go to the Settings gear in the lower left, choose "Vault," and select the directory your notes are in.
+If you already have a collection of notes in markdown format, just choose them for your Vault. Choose "Vault" in the lower left and select the directory your notes are in.
 
 If you have notes from Roam Research, Notion, or other systems, [[Import data|here's how to import them]].
 
 If you'd like to know more about Obsidian, you can [[Obsidian|read about our story]].
 
-By the way, you can feel free to edit these help docs, but when you click Settings => Help => Read Help again, they will be overwritten. So, don't put anything in them you want to keep.
+By the way, you can feel free to edit these help docs, but when you open it again, they will be overwritten. So, don't put anything in them you want to keep.
 
 ## I have questions.
 


### PR DESCRIPTION
Some navigation breadcrumbs are outdated. This pull request updates it for v0.12.12 and also fixes inconsistent arrows (>, -> to =>)

Examples:
- > [Settings -> Keymap](https://help.obsidian.md/Plugins/Command+palette)

**Keymap** was renamed to **Hotkeys.**

- > [Settings -> Third-party plugin -> Community plugins -> Browse](https://help.obsidian.md/Advanced+topics/Third-party+plugins)

**Third-party plugin** was renamed to **Community plugins.**

![image](https://user-images.githubusercontent.com/61631665/129405070-6e64e738-5269-40d8-9857-d3aa41d5a49f.png)
