### PR TITLE
Google Analytics: Distinction Between UA and GA4

### DIFF
--- a/en/Licenses & add-on services/Obsidian Publish.md
+++ b/en/Licenses & add-on services/Obsidian Publish.md
@@ -70,7 +70,7 @@ This option adds a meta noindex tag to all your pages so search engines like Goo
 
 ##### Google Analytics
 
-If you wish to setup Google Analytics for your site, first make sure your local laws and regulations allows. Then, you just need to put the tracking code, in the form of `UA-XXXXX-Y` into the text box and your site will automatically track page views. Note that Google Analytics is only available to visitors from your custom domain.
+If you wish to setup Google Analytics for your site, first make sure your local laws and regulations allows. Then, you just need to put the tracking code, in the form of `UA-XXXXX-Y` into the text box and your site will automatically track page views. Make sure to create a Universal Analytics (UA) property, not the new Google Analytics 4 property. Note that Google Analytics is only available to visitors from your custom domain.
 
 When testing Google Analytics, please make sure to disable any ad-blocking browser extensions like uBlock Origin which blocks Google Analytics scripts from running.
 


### PR DESCRIPTION
I added a sentence which clarifies the difference between a Universal Analytics (UA) property and the new Google Analytics 4 property which Publish does not support. More info here: https://support.google.com/analytics/answer/10269537#property