### PR TITLE
fix a word choice

### DIFF
--- a/en/Advanced topics/Contributing to Obsidian.md
+++ b/en/Advanced topics/Contributing to Obsidian.md
@@ -46,4 +46,4 @@ We're in the middle of reorganizing and stabilizing the documentation you're rea
 
 #### Found a typo?
 
-If you found a typo or a grammar mistake in these documentation, feel free to submit a pull request in [our documentation repository](https://github.com/obsidianmd/obsidian-docs).
+If you found a typo or a grammar mistake in the documentation, feel free to submit a pull request in [our documentation repository](https://github.com/obsidianmd/obsidian-docs).


### PR DESCRIPTION
The word `documentation` is, most often than not, referred as a singular noun. In place of `these` it should have been `this`. However, using `the` just solves it.