### PR TITLE
improve phrasing regarding obsidian versions

### DIFF
--- a/en/How to/Update Obsidian.md
+++ b/en/How to/Update Obsidian.md
@@ -8,10 +8,10 @@ You can check your current version, check for updates in Settings => About. You 
 
 If you're looking to update to the latest insider build, please refer to [[Insider builds#How to enable insider build|this guide]] on how to turn it on.
 
-### Current version vs installed version
+### Current version vs Installer version
 
 If you look closely in Settings => About, you can find your current version and your installer version.
 
-Your current version is your Obsidian version. This is the version of the app on top of the engine (which is Electron). It will increase when you auto-update, but your installer version will not. Your installer version will only increase when you install Obsidian with a new installer.
+Your current version is your Obsidian version, i.e. the version of the app running on top of the Electron engine. It increments with auto-updates, but the installer version does not. Your installer version only increments when you (re)install Obsidian with a new installer.
 
-Most features can be delivered by auto-updating, but to update the engine for certain new features Obsidian, we encourage you to grab the latest installer from [our official website](https://obsidian.md) from time to time, when your current version is above the installer version by a lot, for example when your current version is 0.10.8 while installer version is 0.8.3.
+Most features can be delivered by auto-updating, but an updated engine is required for certain new features of Obsidian. We encourage you to grab the latest installer from [our official website](https://obsidian.md) from time to time. Like when there's a huge difference in your current version (e.g. 0.10.8) and the installer version (e.g. 0.8.3).

--- a/en/How to/Update Obsidian.md
+++ b/en/How to/Update Obsidian.md
@@ -8,7 +8,7 @@ You can check your current version, check for updates in Settings => About. You 
 
 If you're looking to update to the latest insider build, please refer to [[Insider builds#How to enable insider build|this guide]] on how to turn it on.
 
-### Current version vs Installer version
+### Current version vs installer version
 
 If you look closely in Settings => About, you can find your current version and your installer version.
 


### PR DESCRIPTION
Phrasing improvement.

Note: In case this phrasing isn't approved, in the original phrasing it should have been `features of  Obsidian` in`but to update the engine for certain new features Obsidian` and `installer version` instead of `installed version`.