### PR TITLE
Add explanation of sync conflicts, and sync not running in background

### DIFF
--- a/en/Licenses & add-on services/Obsidian Sync.md
+++ b/en/Licenses & add-on services/Obsidian Sync.md
@@ -60,6 +60,22 @@ You can right click a file in the file explorer pane to see its version history.
 
 After selecting a version in the left column in the version history screen, you can restore the file to this version by clicking on the "Restore" button.
 
+### Conflicted files
+
+A conflict is when a file is changed in two places, between syncs, and Sync needs to decide what to do with the two sets of changes.
+
+For example:
+- you edit a file on a mobile device without an internet connection.
+- then you make different edits to the same file on a desktop machine, and those changes get uploaded by Obsidian Sync
+- later you return to the vault on the mobile device and have an internet connection
+- now Obsidian downloads changes and finds this file has been changed in different places, and has to resolve the conflicts.
+
+When Sync downloads a new version of a file, and finds that there are conflicts with the local copy, the changes are merged with Google's diff-match-patch algorithm.
+
+This normally works well, although sometimes it does sometime just add one version of the file to the other.
+
+Note that unless you search the sync log for `Merging conflicted file`, there is no visible notification if a conflict has happened, and how it was resolved.
+
 ### Deleted files
 
 After you delete a file, you can view it in Setting => Sync => Deleted files => View.
@@ -141,22 +157,6 @@ No, your data is still in plain text on your hard disk. If you wish to encrypt i
 ##### Is my data synchronized in the background?
 
 No, files are only synchronized when Obsidian is running, and with the vault open, and there is an internet connection.
-
-##### How does Obsidian Sync deal with conflicting changes?
-
-A conflict is when a file is changed in two places, between syncs, and Sync needs to decide what to do with the two sets of changes.
-
-For example:
-- you edit a file on a mobile device without an internet connection.
-- then you make different edits to the same file on a desktop machine, and those changes get uploaded by Obsidian Sync
-- later you return to the vault on the mobile device and have an internet connection
-- now Obsidian downloads changes and finds this file has been changed in different places, and has to resolve the conflicts.
-
-When Sync downloads a new version of a file, and finds that there are conflicts, the changes are merged with Google's diff-match-patch algorithm.
-
-This normally works well, although sometimes it does sometime just add one version of the file to the other.
-
-Note that unless you search the sync log for `Merging conflicted file`, there is no visible notification if a conflict has happened, and how it was resolved
 
 ##### How long is my data kept after my subscription expires?
 

--- a/en/Licenses & add-on services/Obsidian Sync.md
+++ b/en/Licenses & add-on services/Obsidian Sync.md
@@ -138,6 +138,24 @@ At the moment, each remote vault can have up to 10 GB of data, including version
 
 No, your data is still in plain text on your hard disk. If you wish to encrypt it from people who use your computer, you should look for a disk encryption solution.
 
+##### Is my data synchronized in the background?
+
+No, files are only synchronized when Obsidian is running, and with the vault open, and there is an internet connection.
+
+##### How does Obsidian Sync deal with conflicting changes?
+
+A conflict is when a file is changed in two places, between syncs, and Sync needs to decide what to do with the two sets of changes.
+
+For example:
+- you edit a file on a mobile device without an internet connection.
+- then you make different edits to the same file on a desktop machine, and those changes get uploaded by Obsidian Sync
+- later you return to the vault on the mobile device and have an internet connection
+- now Obsidian downloads changes and finds this file has been changed in different places, and has to resolve the conflicts.
+
+When Sync downloads a new version of a file, and finds that there are conflicts, the changes are merged with Google's diff-match-patch algorithm.
+
+This normally works well, although sometimes it does sometime just add one version of the file to the other.
+
 ##### How long is my data kept after my subscription expires?
 
 Data in your remote vaults, including version history, is kept for one month for you, after your subscription expires.

--- a/en/Licenses & add-on services/Obsidian Sync.md
+++ b/en/Licenses & add-on services/Obsidian Sync.md
@@ -156,6 +156,8 @@ When Sync downloads a new version of a file, and finds that there are conflicts,
 
 This normally works well, although sometimes it does sometime just add one version of the file to the other.
 
+Note that unless you search the sync log for `Merging conflicted file`, there is no visible notification if a conflict has happened, and how it was resolved
+
 ##### How long is my data kept after my subscription expires?
 
 Data in your remote vaults, including version history, is kept for one month for you, after your subscription expires.

--- a/en/Licenses & add-on services/Obsidian Sync.md
+++ b/en/Licenses & add-on services/Obsidian Sync.md
@@ -72,8 +72,6 @@ For example:
 
 When Sync downloads a new version of a file, and finds that there are conflicts with the local copy, the changes are merged with Google's diff-match-patch algorithm.
 
-This normally works well, although sometimes it does sometime just add one version of the file to the other.
-
 Note that unless you search the sync log for `Merging conflicted file`, there is no visible notification if a conflict has happened, and how it was resolved.
 
 ### Deleted files


### PR DESCRIPTION
This is to try and capture some useful info from the obsidian-sync Discord channel this morning, including the info:

https://discord.com/channels/686053708261228577/900870622631063552/907925338674311200

> They are merged with Google's diff match patch algorithm, which normally does a good job but I've seen it sometimes just adds one version to the other

I started with all the new text being in the FAQ section, but it got a bit long, so I moved it to the main body.