### PR TITLE
Installation guide

### DIFF
--- a/en/Concepts/Current version.md
+++ b/en/Concepts/Current version.md
@@ -1,3 +1,0 @@
-Your current version is your Obsidian version. This is the version number that you’ll see in the [[Title bar]] and the [[Vault switcher]].
-
-You can have most of the new features and bug fixes by having an up-to-update current version. However, for some low-level updates, you might need to bring the [[Installer version]] up to date. 

--- a/en/Concepts/Installer version.md
+++ b/en/Concepts/Installer version.md
@@ -1,7 +1,0 @@
-If you look closely in Settings -> About, you can find your current version and your installer version.
-
-Installer version will not increase when you [[Update Obsidian|auto-update]], unlike the [[Current version]]. Your installer version will only increase when you install Obsidian with a new installer.
-
-To grab the latest installer, please go to our [[official website]].
-
-Most features can be delivered by auto-updating, but to update the engine for certain new features Obsidian, we encourage you to grab the latest installer from [our official website](https://obsidian.md) from time to time, when your current version is above the installer version by a lot, for example when your current version is 0.10.8 while installer version is 0.8.3.

--- a/en/Getting started/Download and install Obsidian.md
+++ b/en/Getting started/Download and install Obsidian.md
@@ -1,0 +1,71 @@
+This page lists all supported ways to download and install Obsidian.
+
+## Install Obsidian on Windows
+
+1. Open your browser and go to [Download Obsidian](https://obsidian.md/download).
+2. Under **Windows**, click **64-bit installer** to download the installation file.
+3. Open the installation file and follow the instructions.
+4. Open Obsidian the same way you would open any other application.
+
+## Install Obsidian on macOS
+
+1. Open your browser and go to [Download Obsidian](https://obsidian.md/download).
+2. Under **macOS**, click **Universal DMG (Intel and M1)** to download the installation file.
+3. Open the installation file.
+4. In the window that opens, drag Obsidian to the Applications folder.
+5. Open Obsidian the same way you would open any other application.
+
+## Install Obsidian on Linux
+
+If you use Linux, you can install Obsidian in several ways. Follow the instructions for the packaging system that you're using.
+
+### Install Obsidian using Snap
+
+1. Open your browser and go to [Download Obsidian](https://obsidian.md/download).
+2. Under **Linux**, click **Snap** to download the installation file.
+3. Open a terminal and navigate to the folder where you downloaded the installation file.
+4. In the terminal, run the following command to install the Snap package:
+
+   ```bash
+   snap install obsidian_<version>_<arch>.snap
+   ```
+
+5. Open Obsidian the same way you would open any other application.
+
+### Install Obsidian using AppImage
+
+1. Open your browser and go to [Download Obsidian](https://obsidian.md/download).
+2. Under **Linux**, click **AppImage** to download the installation file.
+3. Open a terminal and navigate to the folder where you downloaded the installation file.
+4. In the terminal, run the following command to open Obsidian:
+
+   ```bash
+   chmod u+x Obsidian-<version>.AppImage
+   ./Obsidian-<version>.AppImage
+   ```
+
+### Install Obsidian using Flatpak
+
+1. In your terminal, run the following command to install Obsidian:
+
+   ```bash
+   flatpak install flathub md.obsidian.Obsidian
+   ```
+
+2. Open Obsidian by running the following command:
+
+   ```bash
+   flatpak run md.obsidian.Obsidian
+   ```
+
+## Install Obsidian on Android
+
+1. Find Obsidian on the [Play Store](https://play.google.com/store/apps/details?id=md.obsidian)
+2. Tap **Install** to download the app.
+3. Open Obsidian the same way you would open any other app.
+
+## Install Obsidian on iPhone and iPad
+
+1. Find Obsidian on the [App Store](https://apps.apple.com/us/app/obsidian-connected-notes/id1557175442)
+2. Tap **Get** to download the app.
+3. Open Obsidian the same way you would open any other app.

--- a/en/Getting started/Download and install Obsidian.md
+++ b/en/Getting started/Download and install Obsidian.md
@@ -60,12 +60,12 @@ If you use Linux, you can install Obsidian in several ways. Follow the instructi
 
 ## Install Obsidian on Android
 
-1. Find Obsidian on the [Play Store](https://play.google.com/store/apps/details?id=md.obsidian)
+1. Find Obsidian on the [Play Store](https://play.google.com/store/apps/details?id=md.obsidian).
 2. Tap **Install** to download the app.
 3. Open Obsidian the same way you would open any other app.
 
 ## Install Obsidian on iPhone and iPad
 
-1. Find Obsidian on the [App Store](https://apps.apple.com/us/app/obsidian-connected-notes/id1557175442)
+1. Find Obsidian on the [App Store](https://apps.apple.com/us/app/obsidian-connected-notes/id1557175442).
 2. Tap **Get** to download the app.
 3. Open Obsidian the same way you would open any other app.

--- a/en/Getting started/Update Obsidian.md
+++ b/en/Getting started/Update Obsidian.md
@@ -1,0 +1,20 @@
+Obsidian checks for new updates regularly. When a new update is available, Obsidian applies it when you restart the application.
+
+## Check for an update and the current version
+
+Open **Settings** ->  **About**.
+
+You can find the current Obsidian version and installer version in the top-left corner.
+
+To apply any available updates, click **Relaunch**.
+
+## Disable automatic updates
+
+If you prefer to update Obsidian manually, you can disable automatic updates.
+
+1. Open **Settings** ->  **About**.
+2. Disable **Automatic updates**.
+
+## Troubleshooting
+
+Some features may depend on a more recent installer version. If you experience issues with a recently added feature, consider [[Download and install Obsidian|reinstalling Obsidian]] to update the installer version.

--- a/en/Obsidian/Official website.md
+++ b/en/Obsidian/Official website.md
@@ -2,6 +2,6 @@ Obsidian’s official website is at https://obsidian.md/.
 
 It’s useful for:
 
-1. Grabbing the latest installer if your [[Installer version]] is too low;
-2. Register an account if you want to purchase [[Catalyst license]], [[Commercial license]], [[Introduction to Obsidian Sync|Obsidian Sync]], or [[Introduction to Obsidian Publish|Obsidian Publish]];
+1. Grabbing the latest installer if your installer version is too old;
+2. Register an account if you want to purchase [[Catalyst license]], [[Commercial license]], [[Introduction to Obsidian Sync|Obsidian Sync]], or [[Obsidian Publish]];
 3. Playing a [quiz game](https://obsidian.md/quiz) if you’re confident with your knowledge of the community plugins and themes.

--- a/en/User interface/Vault switcher.md
+++ b/en/User interface/Vault switcher.md
@@ -4,7 +4,7 @@ Vault switcher lets you switching between existing vaults and create new vaults.
 
 To open the vault switcher, click on the vault icon at the bottom group of the [[Ribbon]] actions. The tooltip text should say “Open another vault”.
 
-You can see the [[#current vault list]] and [[#create new vaults]] here. Because this is the first screen new users see, it also displays name of the program and the [[current version]], along with a dropdown to switch [[Interface language]].
+You can see the [[#current vault list]] and [[#create new vaults]] here. Because this is the first screen new users see, it also displays name of the program and the current version, along with a dropdown to switch [[Interface language]].
 
 ## Current vault list
 


### PR DESCRIPTION
This PR adds a new top-level category "Getting started" with two new pages:

- **Download and install Obsidian** contains guides for installing Obsidian on every supported platform.
- **Update Obsidian** contains guides for managing updates and checking the current version

Was a little unsure about how to recommend users to update the installer version. Most users probably don't know what a "minor" version is. Maybe we could recommend a time period instead, e.g. "every other month"? 

> If the installer version differs from the current version by several minor versions, consider reinstalling Obsidian.

