### PR TITLE
Create Getting started guides

### DIFF
--- a/en/Getting started/Create a vault.md
+++ b/en/Getting started/Create a vault.md
@@ -1,0 +1,20 @@
+A vault is a folder on your local file system where Obsidian stores your notes. You can keep all your notes in one vault, or create several vaults for each of your different projects.
+
+The first time you open Obsidian, you'll be asked to add a new vault from the [[Vault switcher]].
+
+To create a new empty vault from the vault switcher:
+
+1. To the right of **Create new vault**, click **Create**.
+2. In **Vault name**, enter the name of your vault.
+3. Click **Browse** to select where your new vault will be created.
+4. Click **Create**.
+
+If you already have a folder that you want to use as your vault:
+
+1. To the right of **Open folder as vault**, click **Open**.
+2. In the file browser, select the folder you want to use as your vault.
+3. Click **Open**.
+
+If you want to know more about how vaults work, learn how [[How Obsidian stores data]].
+
+Now that you've set up your vault, you're ready to [[Create your first note]].

--- a/en/Getting started/Create your first note.md
+++ b/en/Getting started/Create your first note.md
@@ -1,0 +1,34 @@
+Notes in Obsidian are stored as plain text files, which makes them incredibly portable. By writing your notes in plain text, they'll outlive any app—even Obsidian itself. If you plan to keep your notes for a long time, this is great news!
+
+## Create a new note
+
+To create a new note:
+
+1. Press Ctrl+N (or Cmd+N on macOS) on your keyboard.
+2. Type "Obsidian" as the name of your note and press Enter.
+3. Copy and paste the following text into your note:
+
+> Obsidian is a powerful knowledge base on top of a local folder of plain text Markdown files.
+
+## Format your note
+
+Obsidian also supports [Markdown](https://en.wikipedia.org/wiki/Markdown)—a markup language for adding formatting to plain text files.
+
+1. Copy and paste the following text at the top of the Obsidian note:
+
+   > \# A second brain, for you, forever.
+
+   The hashtag (#) turns a row of text into a heading.
+
+2. In your note, select the text "knowledge base" and press Ctrl+B (or Cmd+B on macOS) to make it bold.
+
+To learn more about how to format your notes using Markdown, refer to [[Format your notes]].
+
+## Read and edit your note
+
+If you want to focus on reading, and you find the Markdown syntax distracting, you can toggle between the Reading and Editing views.
+
+1. In the top right corner of your note, click the the glasses icon to switch to the Reading view.
+2. Click the icon again (now a pen icon) to switch to the Editing view.
+
+By default, notes use the Editing view when you first open them. You can change the default view to use when you open a new note, by setting the **Default new pane view** under **Settings** -> **Editor**.

--- a/en/Getting started/Create your first note.md
+++ b/en/Getting started/Create your first note.md
@@ -25,3 +25,7 @@ Obsidian also supports [Markdown](https://en.wikipedia.org/wiki/Markdown)—a ma
 By default, Obsidian only displays the Markdown syntax for the text under the text cursor. If you move your cursor, the syntax disappears and instead you see the formatted text.
 
 To learn more about how to format your notes using Markdown, refer to [[Format your notes]].
+
+## Learn more
+
+Learn how to [[Link notes|link notes]] to create a network of connected thoughts.

--- a/en/Getting started/Create your first note.md
+++ b/en/Getting started/Create your first note.md
@@ -22,13 +22,6 @@ Obsidian also supports [Markdown](https://en.wikipedia.org/wiki/Markdown)—a ma
 
 2. In your note, select the text "knowledge base" and press Ctrl+B (or Cmd+B on macOS) to make it bold.
 
+By default, Obsidian only displays the Markdown syntax for the text under the text cursor. If you move your cursor, the syntax disappears and instead you see the formatted text.
+
 To learn more about how to format your notes using Markdown, refer to [[Format your notes]].
-
-## Read and edit your note
-
-If you want to focus on reading, and you find the Markdown syntax distracting, you can toggle between the Reading and Editing views.
-
-1. In the top right corner of your note, click the the glasses icon to switch to the Reading view.
-2. Click the icon again (now a pen icon) to switch to the Editing view.
-
-By default, notes use the Editing view when you first open them. You can change the default view to use when you open a new note, by setting the **Default new pane view** under **Settings** -> **Editor**.

--- a/en/Getting started/Create your first note.md
+++ b/en/Getting started/Create your first note.md
@@ -22,8 +22,6 @@ Obsidian also supports [Markdown](https://en.wikipedia.org/wiki/Markdown)—a ma
 
 2. In your note, select the text "knowledge base" and press Ctrl+B (or Cmd+B on macOS) to make it bold.
 
-By default, Obsidian only displays the Markdown syntax for the text under the text cursor. If you move your cursor, the syntax disappears and instead you see the formatted text.
-
 To learn more about how to format your notes using Markdown, refer to [[Format your notes]].
 
 ## Learn more

--- a/en/Getting started/Link notes.md
+++ b/en/Getting started/Link notes.md
@@ -1,0 +1,51 @@
+# Link notes
+
+While Obsidian is great for taking notes, the true power of Obsidian lies in being able to link your notes together. By understanding how one piece of information relates to another, you can improve your ability to remember them and to form deeper insights. In this guide, you'll learn how to create and navigate links in Obsidian.
+
+## Step 1: Create a link
+
+In this step, you'll create two notes and link them together using the \[\[double bracket syntax\]\].
+
+1. [[Create your first note|Create a note]] with the name "Three laws of motion":
+
+   > The laws of motion are three laws stated by Isaac Newton, that describe the relationship between the motion of an object, and the forces acting on it.
+
+1. Create another note with the name "Law of Inertia" with the following text:
+
+   > The Law of Inertia is one of the
+
+1. At the end of the sentence, press the left square bracket (`[`) twice on your keyboard.
+1. Type "three" to find the first note you created.
+1. Press Enter to create a link to the highlighted note.
+
+   > The Law of Inertia is one of the \[\[Three laws of motion\]\]
+
+Open the "Three laws of motion" note by clicking on the link while pressing Ctrl (or Cmd on macOS).
+
+## Step 2: Create a link to a non-existing note
+
+You can create links to notes that don't exist yet, for when you want to dive into a topic at a later time.
+
+1. In your "Three laws of motion" note, select the text "Isaac Newton".
+1. Press the left square bracket (`[`) twice on your keyboard to create a link. The second link has a more muted color to indicate that the note doesn't exist yet.
+1. Create the note by clicking on the link while pressing Ctrl (or Cmd on macOS).
+
+## Step 3: Navigate between notes
+
+As you've seen in the previous steps, you can click a link while pressing Ctrl (or Cmd on macOS) to go to the linked note.
+
+Another way to navigate the between notes is through _backlinks_. A backlink lets you navigate in the opposite direction of an existing link.
+
+1. Open the "Isaac Newton" note.
+1. In the right side bar, click the **Backlinks** tab.
+1. Under **Linked mentions**, click the mention in "Three laws of motion" to go to that note.
+
+Another way to navigate between your notes is by using a visual representation of how your notes are connected.
+
+1. In the top-right corner of the note, click **More options** (three dots).
+1. Select **Open local graph**.
+1. Click any of the nodes in the graph to navigate to that note.
+
+## Learn more
+
+Understanding how your notes are connected becomes increasingly more difficult as your vault grows. Learn how to use the [[graph view]] to gain deeper insights from your knowledge base.


### PR DESCRIPTION
This pull request adds the two pages for the Getting started docs:

- After reading **Create a vault** the reader should know how to:
  - Create a vault (but not necessarily understand the details)
- After **Create your first note** the reader should know how to:
  - Create a note
  - Use basic Markdown formatting
  - Switch between Editing and Reading views

These are intended to directly follow the installation guide and don't assume any previous knowledge about Obsidian.

## Considerations

- I've opted to use the keyboard shortcut (rather than using the File explorer) for creating a note, to shorten the time before the reader can start writing. 
- The Create your first note page aims to focus only on the note pane to limit the number of UI elements the user needs to interact with.