### PR TITLE
add back mobile insider explanation

### DIFF
--- a/en/Advanced topics/Insider builds.md
+++ b/en/Advanced topics/Insider builds.md
@@ -11,3 +11,35 @@ If you are a [[Catalyst license|Catalyst supporter]], you have access to Insider
 ### Report issues
 
 If you're on our Discord server, you can go to the #insider-build channel to report issues. If you're filing a bug report on the forum, be sure to note the version you're using, so that we can improve it before rolling it out to everyone.
+
+## Mobile insider builds
+
+If you're a holder of the [[Catalyst license]], you may wish to join our [[Insider builds|insider builds]] for mobile.
+
+To keep feedback and releases centralized as we don't have the capacity to debug and collect feedback via email, we ask Catalyst users who would like to beta test to go through the following steps:
+
+### Step 1: join our Discord
+
+First of all, please [join our Discord](https://discord.gg/veuWUTm).  
+
+### Step 2: claim your Catalyst badge to access \#insider-build-mobile channel
+
+If you don't have your badge yet, [[Catalyst license#Discord badge|you can get it in your Account page]].
+
+### Step 3: get the app via TestFlight (iOS) or APK (Android)
+
+Once you get your badge, you should be able to see the `#insider-mobile` channel along with regular channels like `#general` and `#publish`.
+
+To find the instructions for installing the mobile apps, go to `#insider-mobile`, and open pinned messages.
+
+On Discord web and desktop, you can open pinned messages of a channel by clicking on the pushpin icon near the search bar at the top. On Discord mobile, you'll need to swipe left to reveal the right sidebar and tap on the pushpin icon at the top.
+
+For the iOS app, look for the TestFlight link. Make sure to open the link on your iPhone or iPad, rather than on your computer. For the Android app, install the APK from the latest pinned messages if there are several of them.
+
+### How do I provide feedback?
+
+Before reporting an issue or submitting a feature request, please visit [the list of known issues on our forum](https://forum.obsidian.md/t/list-of-known-issues/14286) to see what's already known and on the roadmap.
+
+The current group being rolled out can access the `#insider-mobile` channel on Discord as well as the new Mobile category on the forum.
+
+To keep track of bug reports and feature requests, please direct them to the forum as usual. Thank you for trying out our beta!

--- a/en/Advanced topics/Insider builds.md
+++ b/en/Advanced topics/Insider builds.md
@@ -40,6 +40,4 @@ For the iOS app, look for the TestFlight link. Make sure to open the link on you
 
 Before reporting an issue or submitting a feature request, please visit [the list of known issues on our forum](https://forum.obsidian.md/t/list-of-known-issues/14286) to see what's already known and on the roadmap.
 
-The current group being rolled out can access the `#insider-mobile` channel on Discord as well as the new Mobile category on the forum.
-
 To keep track of bug reports and feature requests, please direct them to the forum as usual. Thank you for trying out our beta!


### PR DESCRIPTION
This makes the issue reporting for desktop and mobile a bit inconsistent, in that it doesn't explain how to join Discord for the desktop insider, but the mobile insider program. That's something which should be tackled later.