### PR TITLE
Update Internal link.md

### DIFF
--- a/en/How to/Internal link.md
+++ b/en/How to/Internal link.md
@@ -22,4 +22,4 @@ To make the link display different text than its real note name in Preview, use 
 
 Internal links could be written in two formats:
 - `Wikilink` in the following format: `[[My Link]]`;
-- `Markdown style links` in the following format: `[My Link](../Some%20Other%Folder/My%20Link.md)`. It is similar to [[Format your notes#External links]] but it uses URLs relative to the current note.
+- `Markdown-style links` in the following format: `[My Link](My%20Link.md)`. 


### PR DESCRIPTION
Removed the wording about using relative path mode. In Obsidian, The style type (wikilink, markdown) and the path format (shortest, relative, absolute) are orthogonal.