### PR TITLE
Fix mistake in callout types

### DIFF
--- a/en/How to/Use callouts.md
+++ b/en/How to/Use callouts.md
@@ -20,13 +20,14 @@ It will show up like this:
 
 ### Types
 
-By default, there are 12 distinct callout types, each with several aliases. Each type comes with a different background color and icon.
+By default, there are 13 distinct callout types, each with several aliases. Each type comes with a different background color and icon.
 
 To use these default styles, replace `INFO` in the examples with any of these types. Any unrecognized type will default to the "note" type, unless they are [[#Customizations|customized]]. The type identifier is case insensitive.
 
 - note
 - abstract, summary, tldr
-- info, todo
+- info
+- todo
 - tip, hint, important
 - success, check, done
 - question, help, faq


### PR DESCRIPTION
Docs said that 'info' and 'todo' are aliases for the same callout when they are not. The icons are different between them but they have the same colour. 
![image](https://user-images.githubusercontent.com/38633150/183122413-89d5c6f3-8c48-44cc-85b1-8f3eea7b4b42.png)
