### PR TITLE
Add guide for Google Analytics

### DIFF
--- a/en/Obsidian Publish/Set up Google Analytics.md
+++ b/en/Obsidian Publish/Set up Google Analytics.md
@@ -1,0 +1,24 @@
+[Google Analytics](https://analytics.google.com) is a service that allows you to track traffic on your website. This page explains how to enable Google Analytics for your [[Introduction to Obsidian Publish|Obsidian Publish]] site.
+
+> **Important:** Before you enable Google Analytics, make sure that your local laws and regulations allow you to track your visitors.
+
+## Prerequisites
+
+To use Google Analytics for Obsidian, you need:
+
+- A Universal Analytics (UA) property (not the new Google Analytics 4 property).
+- A [[Set up a custom domain|custom domain]] for your Obsidian Publish site.
+
+### Set up Google Analytics
+
+To enable Google Analytics for your Obsidian Publish site:
+
+1. In ribbon, to the left of the application window, click **Publish changes** (paper plane icon).
+2. In the **Publish changes** dialog, click **Change site options** (cog icon).
+4. In **Google Analytics tracking code**, enter your tracking code.
+
+## Troubleshooting
+
+- To verify that your site uses Google Analytics, disable any ad-blocking browser extensions, such as uBlock Origin, that may block the tracking script from running.
+
+- To use Google Tag Manager instead of Google Analytics, use custom JavaScript to add your own scripts.

--- a/en/Obsidian Publish/Set up Google Analytics.md
+++ b/en/Obsidian Publish/Set up Google Analytics.md
@@ -14,8 +14,8 @@ To use Google Analytics for Obsidian, you need:
 To enable Google Analytics for your Obsidian Publish site:
 
 1. In ribbon, to the left of the application window, click **Publish changes** (paper plane icon).
-2. In the **Publish changes** dialog, click **Change site options** (cog icon).
-4. In **Google Analytics tracking code**, enter your tracking code.
+1. In the **Publish changes** dialog, click **Change site options** (cog icon).
+1. In **Google Analytics tracking code**, enter your tracking code.
 
 ## Troubleshooting
 

--- a/en/Obsidian Publish/Set up Google Analytics.md
+++ b/en/Obsidian Publish/Set up Google Analytics.md
@@ -7,7 +7,6 @@
 
 To use Google Analytics for Obsidian, you need:
 
-- A Universal Analytics (UA) property (not the new Google Analytics 4 property).
 - A [[Set up a custom domain|custom domain]] for your Obsidian Publish site.
 
 ### Set up Google Analytics

--- a/en/Obsidian Publish/Set up Google Analytics.md
+++ b/en/Obsidian Publish/Set up Google Analytics.md
@@ -1,6 +1,7 @@
 [Google Analytics](https://analytics.google.com) is a service that allows you to track traffic on your website. This page explains how to enable Google Analytics for your [[Introduction to Obsidian Publish|Obsidian Publish]] site.
 
-> **Important:** Before you enable Google Analytics, make sure that your local laws and regulations allow you to track your visitors.
+> [!important]
+> Before you enable Google Analytics, make sure that your local laws and regulations allow you to track your visitors.
 
 ## Prerequisites
 


### PR DESCRIPTION
This PR creates a new guide for how to set up Google Analytics for an Obsidian Publish site.

#268