### PR TITLE
Add docs on hosting media files

### DIFF
--- a/en/Obsidian Publish/Hosting media files.md
+++ b/en/Obsidian Publish/Hosting media files.md
@@ -1,0 +1,3 @@
+[[Introduction to Obsidian Publish|Obsidian Publish]] lets you host notes and other media types, such as images and video clips, up to 4GB per site.
+
+Note that Obsidian Publish isn't optimized for streaming video. To improve the experience for your visitors, we recommend that you instead use a video hosting service, such as YouTube or Vimeo.


### PR DESCRIPTION
This PR adds a page on Hosting media files under Obsidian Publish.

The previous docs goes into detail why using YouTube is better. I think we can limit ourselves to saying that Obsidian Publish isn't optimized for streaming video. And if you want a better experience, try YouTube or Vimeo.

Fixes #278 