### PR TITLE
Changed "minuses" to "hyphens"

### DIFF
--- a/en/How to/Format your notes.md
+++ b/en/How to/Format your notes.md
@@ -314,7 +314,7 @@ Use two equal signs to ==highlight text==.
 ### Horizontal Bar
 
 ```md
-Use three stars ***, minuses ---, or underscores ___ in a new line to produce an horizontal bar.
+Use three stars ***, hyphens ---, or underscores ___ in a new line to produce an horizontal bar.
 
 ```
 


### PR DESCRIPTION
A minus sign is technically an en dash, which is a different character (which does not work). Also, this same document references "hyphens" elsewhere.