### PR TITLE
Delete docs for Open in default app

### DIFF
--- a/en/Plugins/Core plugins.md
+++ b/en/Plugins/Core plugins.md
@@ -15,7 +15,6 @@ Plugins can be managed through the "Settings" button on the bottom left. Some of
 1. [[Graph view]]
 1. [[Markdown format converter]]
 1. [[Note composer]]
-1. [[Open in default app]]
 1. [[Outgoing links]]
 1. [[Outline]]
 1. [[Page preview]]

--- a/en/Plugins/Open in default app.md
+++ b/en/Plugins/Open in default app.md
@@ -1,5 +1,0 @@
-Opens the current file with default app on your computer. You can access it at the top right corner of the file top bar:
-
-![[Pasted image 5.png]]
-
-It's useful for editing images or annotating PDFs, among other things.


### PR DESCRIPTION
The core plugin Open in default app was moved into core in [v0.15.6](https://forum.obsidian.md/t/obsidian-release-v0-15-6/40227).