### PR TITLE
Update docs for Outline and Page preview plugins

### DIFF
--- a/en/Plugins/Outline.md
+++ b/en/Plugins/Outline.md
@@ -1,1 +1,5 @@
-The outline plugin shows the list of headings for the active note and allows you to navigate to another section by clicking on a heading.
+The Outline plugin lists the headings in the active note.
+
+To navigate to that section in the note, click on the heading in the outline.
+
+To rearrange sections in the note, click and drag the heading within the outline.

--- a/en/Plugins/Outline.md
+++ b/en/Plugins/Outline.md
@@ -1,1 +1,1 @@
-The outline plugin shows the list of headings for the current note, and allows you to navigate to another section by clicking on a heading.
+The outline plugin shows the list of headings for the active note and allows you to navigate to another section by clicking on a heading.

--- a/en/Plugins/Page preview.md
+++ b/en/Plugins/Page preview.md
@@ -3,4 +3,4 @@ Page preview lets you preview a page when you hover the cursor over an internal 
 To preview a page while in Editing view, press Ctrl (or Cmd on macOS) while hovering the cursor over the link.
 
 > [!tip]
-> Page preview even works inside the preview window.
+> In the plugin settings, you can configure Page preview to only open the preview automatically, or only when you press Ctrl (or Cmd on macOS).

--- a/en/Plugins/Page preview.md
+++ b/en/Plugins/Page preview.md
@@ -1,5 +1,7 @@
 Page preview lets you preview a page when you hover the cursor over an internal link, without needing to navigate to that page.
 
+In addition to editor, you can preview notes in several other parts of Obsidian, such as [[File explorer]], [[Search]], and [[Backlinks]].
+
 To preview a page while in Editing view, press Ctrl (or Cmd on macOS) while hovering the cursor over the link.
 
 > [!tip]

--- a/en/Plugins/Page preview.md
+++ b/en/Plugins/Page preview.md
@@ -1,5 +1,6 @@
-Page preview lets you preview a page when hovering an internal link, without needing to actually navigate to that page.
+Page preview lets you preview a page when you hover the cursor over an internal link, without needing to navigate to that page.
 
-![[Pasted image 13.png]]
+To preview a page while in Editing view, press Ctrl (or Cmd on macOS) while hovering the cursor over the link.
 
-This works on the preview pane. In the editor, you can hover a link while holding `Ctrl/Cmd`, which will open the preview too.
+> [!tip]
+> Page preview even works inside the preview window.


### PR DESCRIPTION
Only minor style issues here. Also, I went ahead and removed the screenshot for consistency.