### PR TITLE
Re-write the development section to remove the beta hint

### DIFF
--- a/en/Obsidian/Obsidian.md
+++ b/en/Obsidian/Obsidian.md
@@ -55,6 +55,6 @@ We support [[Customizing CSS|custom CSS]] and have a [[Community plugins|beta pl
 
 ## Follow our development
 
-Obsidian is stable and public available. We still have grand plans to continue making Obsidian the best and most refined thought-processing app for decades to come. On the [roadmap](https://trello.com/b/Psqfqp7I/obsidian-roadmap) you can see where we are headed.
+Curious how we continue to make Obsidian the best and most refined tool for thought-processing? Check out our [roadmap](https://trello.com/b/Psqfqp7I/obsidian-roadmap) to see what we're working on.
 
 Our Twitter handle is [@obsdmd](https://twitter.com/obsdmd), feel free to follow. We mostly tweet about product updates.

--- a/en/Obsidian/Obsidian.md
+++ b/en/Obsidian/Obsidian.md
@@ -55,6 +55,6 @@ We support [[Customizing CSS|custom CSS]] and have a [[Community plugins|beta pl
 
 ## Follow our development
 
-Obsidian is in public beta right now. We have [a roadmap](https://trello.com/b/Psqfqp7I/obsidian-roadmap) that you can check out.
+Obsidian is stable and public available. We still have grand plans to continue making Obsidian the best and most refined thought-processing app for decades to come. On the [roadmap](https://trello.com/b/Psqfqp7I/obsidian-roadmap) you can see where we are headed.
 
 Our Twitter handle is [@obsdmd](https://twitter.com/obsdmd), feel free to follow. We mostly tweet about product updates.


### PR DESCRIPTION
Since version 1.0, obsidian dropped the beta status. I rewrote the section in my words, but if you have a better wording, just overwrite :-) 