### PR TITLE
Clarify how to resize images in tables

### DIFF
--- a/en/How to/Format your notes.md
+++ b/en/How to/Format your notes.md
@@ -363,6 +363,18 @@ First Header | Second Header
 ------------ | ------------
 [[Format your notes\|Formatting]]	|  [[Use hotkeys\|hotkeys]]	
 
+If you want to resize images in tables, the pipe must be escaped with a `\` as well:
+
+```md
+Image | Description
+----- | -----------
+![[og-image.png\|200]] | Obsidian
+```
+
+Image | Description
+----- | -----------
+![[og-image.png\|200]] | Obsidian
+
 ---
 
 ### Strikethrough

--- a/en/How to/Format your notes.md
+++ b/en/How to/Format your notes.md
@@ -363,7 +363,7 @@ First Header | Second Header
 ------------ | ------------
 [[Format your notes\|Formatting]]	|  [[Use hotkeys\|hotkeys]]	
 
-If you want to resize images in tables, the pipe must be escaped with a `\` as well:
+If you want to resize images in tables, you need to escape the pipe with a `\`:
 
 ```md
 Image | Description


### PR DESCRIPTION
The pipe character needs to be escaped when resized image is put inside a table, but users seem to struggle with this, eg.:

- https://forum.obsidian.md/t/downsizing-an-image-does-not-work-when-the-image-is-in-a-table/7508
- https://forum.obsidian.md/t/resize-image-within-a-table/30687

I've only found out how to do this after writing a bug report and then finding these older closed topics via the "Your topic is similar to..." before submitting it. A brief mention in the docs would be nice I think :)