### PR TITLE
Update Download and install Obsidian doc

### DIFF
--- a/en/Getting started/Download and install Obsidian.md
+++ b/en/Getting started/Download and install Obsidian.md
@@ -27,7 +27,7 @@ If you use Linux, you can install Obsidian in several ways. Follow the instructi
 4. In the terminal, run the following command to install the Snap package:
 
    ```bash
-   snap install obsidian_<version>_<arch>.snap
+   snap install obsidian_<version>_<arch>.snap --dangerous --classic
    ```
 
 5. Open Obsidian the same way you would open any other application.

--- a/en/Getting started/Download and install Obsidian.md
+++ b/en/Getting started/Download and install Obsidian.md
@@ -24,7 +24,7 @@ If you use Linux, you can install Obsidian in several ways. Follow the instructi
 1. Open your browser and go to [Download Obsidian](https://obsidian.md/download).
 2. Under **Linux**, click **Snap** to download the installation file.
 3. Open a terminal and navigate to the folder where you downloaded the installation file.
-4. In the terminal, run the following command to install the Snap package:
+4. In the terminal, run the following command to install the Snap package: (the `--dangerous` flag is required because Canonical, the company who created Snap, did not review our package, the `--classic` flag allows Obsidian to access outside of the sandbox, where your notes are stored)
 
    ```bash
    snap install obsidian_<version>_<arch>.snap --dangerous --classic


### PR DESCRIPTION
Added needed flags to the snap installation method.

Without `--dangerous`: 
>error: cannot find signatures with metadata for snap "obsidian_1.0.3_amd64.snap"

Without `--classic`:
>error: This revision of snap "obsidian_1.0.3_amd64.snap" was published using classic confinement
       and thus may perform arbitrary system changes outside of the security sandbox that snaps are
       usually confined to, which may put your system at risk.
