### PR TITLE
Clarify syncing of settings for Core plugins

### DIFF
--- a/en/Contributing to Obsidian/Style guide.md
+++ b/en/Contributing to Obsidian/Style guide.md
@@ -26,6 +26,7 @@ This page lists any deviances from the Google style guide, or terminology worth 
 - Prefer "note name" over "note title".
 - Prefer "active note" over "current note".
 - Prefer "folder" over "directory".
+- Prefer "file type" over "file format", unless specifically referring to the data format of the file content.
 
 When moving between notes, use "open" if the destination is hidden, and "switch" if both source and destination notes are open in separate splits.
 

--- a/en/Obsidian Sync/Select files and settings to sync.md
+++ b/en/Obsidian Sync/Select files and settings to sync.md
@@ -5,7 +5,7 @@ Any files or settings that have been synced to your [[Local and remote vaults|re
 - Synced files remain in your remote vault even if you exclude them later on. If possible, configure the files and settings you want to sync before you start syncing your vault.
 - Settings are only synced during start-up. If you change what settings to sync, you need to restart Obsidian on your other devices for the new changes to take effect.
 
-## Select settings to sync
+## Sync vault configuration
 
 1. Open **Settings** -> **Sync**.
 2. Under **Vault configuration sync**, enable the settings you want to sync.

--- a/en/Obsidian Sync/Set up Obsidian Sync.md
+++ b/en/Obsidian Sync/Set up Obsidian Sync.md
@@ -36,3 +36,8 @@ In this guide, you'll enable [[Introduction to Obsidian Sync|Obsidian Sync]] for
 1. In **Encryption password**, enter the password you configured for the vault.
 1. Click **Unlock vault**.
 1. Click **Start syncing**.
+
+> [!note] Sync settings and other file types
+> By default, Sync only syncs notes and images. For information how to sync other file types, refer to [[Select files and settings to sync#Select file types to sync|Select file types to sync]].
+>
+> If you want to sync vault configuration, such as settings for [[Core plugins]], [[Custom hotkeys]], or [[Community plugins]], learn how to [[Select files and settings to sync#Sync vault configuration|Sync vault configuration]].


### PR DESCRIPTION
- Rephrases "Select settings to sync" as "Sync vault configuration". Since no vault configuration is synced by default, "select settings to sync" might give the impression that it's mainly for disabling settings you don't want to sync. "Sync vault configuration" indicates that you follow the steps to sync it at all.
- Adds a callout in the set up guide to inform the reader of the things Obsidian _doesn't_ sync by default, and you might want to enable.
- Adds "file type" > "file format" to the style guide.

Fixes #354 