### PR TITLE
Update Commercial license.md

### DIFF
--- a/en/Licenses & Payment/Commercial license.md
+++ b/en/Licenses & Payment/Commercial license.md
@@ -46,25 +46,28 @@ For bulk discounts, contact support@obsidian.md.
 > Ask your IT department to contact support@obsidian.md if they have questions or require any specific paperwork.
 
 > [!FAQ]- Q8. Do I need a commercial license?
-> From our EULA, if you use OBSIDIAN for commercial use, you must obtain a commercial license. Commercial use is defined as using OBSIDIAN for work-related activities in a company with two (2) or more employees.
+> From our EULA, if you use Obsidian for commercial use, you must obtain a commercial license. Commercial use is defined as using Obsidian for work-related activities in a company with two (2) or more employees.
 
-> [!FAQ]- Q9: I'm a freelancer/writer/blogger, do I need a commercial license?
-> Unless you hire at least one additional person, you do not need a commercial license.
+> [!FAQ]- Q9: I'm a writer/blogger, do I need a commercial license?
+> If your writing is for-profit (e.g., you write on a blog that generates revenue via ads or sponsorships) and your business employs two or more people, yes, you need a commercial license.
 
-> [!FAQ]- Q10: I'm a teacher/professor, or I work at a school, and I use Obsidian for my teaching/lectures. Do I need a commercial license?
+> [!FAQ]- Q10: I'm a solo freelancer/consultant, but my work indirectly contributes to "revenue-generating, work-related activities in a company that has two or more people". Do I need a commercial license?
+> No, as long as you remain the sole employee of your freelance/consulting business, you do not need a commercial license.
+
+> [!FAQ]- Q11: I'm a teacher/professor, or I work at a school, and I use Obsidian for my teaching/lectures. Do I need a commercial license?
 > Obsidian usage for education-related activities within schools and other recognized educational institutions does not require a commercial license. 
 
-> [!FAQ]- Q11: I'm an academic researcher and I use Obsidian for my research work. Do I need a commercial license?
+> [!FAQ]- Q12: I'm an academic researcher and I use Obsidian for my research work. Do I need a commercial license?
 > If your research involves producing a commercial product (e.g., if your research contributes to revenue-generating commercial activities), you need a commercial license for your usage. If your research does not contribute to a commercial product, or if your research has not yet led to commercial activities, you do not need a license.
 
-> [!FAQ]- Q12: I work for a government or an arm's length body or agency. Do I need a commercial license?
+> [!FAQ]- Q13: I work for a government or an arm's length body or agency. Do I need a commercial license?
 > Yes, you need a commercial license. From our EULA, if you use Obsidian for commercial use, you must obtain a commercial license. Commercial use is defined as using Obsidian for "work-related activities in a company with two (2) or more employees". The EULA's revenue-generating clause exempts non-profit organizations.
 
-> [!FAQ]- Q13: I use Obsidian during work for things like writing down team processes and taking notes for team meetings. Do I need a commercial license?
+> [!FAQ]- Q14: I use Obsidian during work for things like writing down team processes and taking notes for team meetings. Do I need a commercial license?
 > If you are a single-person company, then you do not require a commercial license. Otherwise, if you have more than one person in the company, then you would require a commercial license.
 
-> [!FAQ]- Q14: I use Obsidian to store all of my knowledge, both personal and professional, because it's difficult to separate them. Do I need a commercial license?
+> [!FAQ]- Q15: I use Obsidian to store all of my knowledge, both personal and professional, because it's difficult to separate them. Do I need a commercial license?
 > If your notes contain content directly related to work projects or processes for a greater-than-one-person company, then you require a commercial license.
 
-> [!FAQ]- Q15: I’m still not sure if I need a commercial license. What should I do?
+> [!FAQ]- Q16: I’m still not sure if I need a commercial license. What should I do?
 > If you still have questions regarding the commercial license requirements, email us at support@obsidian.md and describe your situation in detail.


### PR DESCRIPTION
A customer made the following point:

> The following two sentences seem to conflict (bold is mine):
> 
> 1- "You need to pay for Obsidian if and only if you use it to contribute, directly or indirectly, to revenue-generating, work-related activities in a company that has two or more people"
> 2- "You don't need a Commercial license if you work in any of the following settings: … Freelancing or companies with a single person". (And further clarified: "Unless you hire at least one additional person, you do not need a commercial license.")
> 
> What if both are true? I'm a self-employed consultant, and I work for a number of different clients at any point in time… so I am a freelancer, and my firm has one person, and I use it to contribute to work-related stuff at larger companies - not sure if that counts as 'direct', 'indirect', both, neither (in/'direct' is not defined).
> 
> Is #2 supposed to override #1? I think this is the intent, based on license clause B ('de minimis') preceding D (commercial). 

So I'm proposing question 10 to clarify this possible contradiction. 

As a result, though, question 9 seemed like a stub. I think the answer should be expanded to be more useful to writers/bloggers — I've proposed a suggestion to do so.

Incidentally this PR also removes the capslocked "OBSIDIAN" mentions from the FAQ.

<sub>PS: I may have proposed this PR already? I remember doing it but can't find it in the repo. ._.</sub>