### PR TITLE
Update Select files and settings to sync.md

### DIFF
--- a/en/Obsidian Sync/Select files and settings to sync.md
+++ b/en/Obsidian Sync/Select files and settings to sync.md
@@ -3,7 +3,8 @@ Any files or settings that have been synced to your [[Local and remote vaults|re
 **Notes:**
 
 - Synced files remain in your remote vault even if you exclude them later on. If possible, configure the files and settings you want to sync before you start syncing your vault.
-- Settings are only synced during start-up. If you change what settings to sync, you need to restart Obsidian on your other devices for the new changes to take effect.
+- If you sync any vault settings, changes will only be updated during start-up. After changing a setting on one device, you will need to restart Obsidian on your other devices for the new changes to take effect. (For example, if you change your Daily Notes' path in the Daily Notes plugin, then create a new daily note on another device without restarting Obsidian, it will use your previous path.)
+- ==Sync doesn't sync Sync's settings.== This allows users to configure Sync differently on each device according to their needs. This means, however, that you must configure custom Sync settings on each device.
 
 ## Sync vault configuration
 


### PR DESCRIPTION
A clarification to the second line under Notes, and adding the gotcha that Sync doesn't sync its own settings (a very common support issue).