### PR TITLE
Add team members to credit page

### DIFF
--- a/en/Obsidian/Credits.md
+++ b/en/Obsidian/Credits.md
@@ -1,13 +1,19 @@
 Names are not listed by amount of contribution, but alphabetically (or at least we try!).
 
-### Dev team
+### Team
 
-- joethei ([Johannes Theiner](https://joethei.xyz/))
-- liam ([Liam Cain](https://liamca.in/)) <span class='flair mod-pop'>Maker of Calendar</span><span class='flair mod-pop'>Plugin API Master</span><span class='flair mod-pop'>Volcano Veteran</span>
-- kepano ([Stephan Ango](https://stephanango.com/))
+#### Development
+
 - Licat (Shida Li)<span class='flair mod-pop'>Obsidian office cat</span>
+- liam ([Liam Cain](https://liamca.in/)) <span class='flair mod-pop'>Maker of Calendar</span><span class='flair mod-pop'>Plugin API Master</span><span class='flair mod-pop'>Volcano Veteran</span>
 - mgmeyers ([Matthew Meyers](https://matthewmeye.rs/))
+- joethei ([Johannes Theiner](https://joethei.xyz/))
+
+#### Product & Operations
+
 - Silver (Erica Xu)<span class='flair mod-pop'>Team Little Silvers</span>
+- kepano ([Stephan Ango](https://stephanango.com/))
+- ryanjamurphy ([Ryan](https://fulcra.design/) [J. A. Murphy](https://axle.design/))
 
 ### Moderators
 

--- a/en/Obsidian/Credits.md
+++ b/en/Obsidian/Credits.md
@@ -30,7 +30,7 @@ Names are not listed by amount of contribution, but alphabetically (or at least 
 
 ### Plugin inspirations
 
-Credits to these ( plugin developers ) for pioneering functionality that were adapted into Obsidian:
+Credits to these plugin developers for pioneering functionality that were adapted into Obsidian:
 
 - pjeby for the Hotkey Helper plugin
 - javalent for the Admonition plugin

--- a/en/Obsidian/Credits.md
+++ b/en/Obsidian/Credits.md
@@ -2,7 +2,11 @@ Names are not listed by amount of contribution, but alphabetically (or at least 
 
 ### Dev team
 
+- joethei ([Johannes Theiner](https://joethei.xyz/))
+- liam ([Liam Cain](https://liamca.in/)) <span class='flair mod-pop'>Maker of Calendar</span><span class='flair mod-pop'>Plugin API Master</span><span class='flair mod-pop'>Volcano Veteran</span>
+- kepano ([Stephan Ango](https://stephanango.com/))
 - Licat (Shida Li)<span class='flair mod-pop'>Obsidian office cat</span>
+- mgmeyers ([Matthew Meyers](https://matthewmeye.rs/))
 - Silver (Erica Xu)<span class='flair mod-pop'>Team Little Silvers</span>
 
 ### Moderators
@@ -12,7 +16,6 @@ Names are not listed by amount of contribution, but alphabetically (or at least 
 - Eleanor ([Eleanor Konik](https://eleanorkonik.com))<span class='flair mod-pop'>Halp Obsidian turned me into a dev</span>
 - koala<span class='flair mod-pop'>Extreme Bug Finder</span>
 - Leah ([Leah Ferguson](http://leahferguson.com))<span class='flair mod-pop'>Roll for initiative!</span><span class='flair mod-pop'>Non-techy Apple geek</span>
-- liam ([Liam Cain](https://liamca.in/)) <span class='flair mod-pop'>Maker of Calendar</span><span class='flair mod-pop'>Plugin API Master</span><span class='flair mod-pop'>Volcano Veteran</span>
 - mediapathic ([Steen Comer](http://mediapathic.net/))<span class='flair mod-pop'>Bad Cop</span>
 - rigmarole ([Chris Lesage](http://rigmarolestudio.com))<span class='flair mod-pop'>Forum master</span>
 - ryanjamurphy ([Ryan](https://fulcra.design/) [J. A. Murphy](https://axle.design/))<span class='flair mod-pop'>That funny guy</span><span class='flair mod-pop'>Apple Fanboy</span><span class='flair mod-pop'>Forum master</span>
@@ -21,7 +24,8 @@ Names are not listed by amount of contribution, but alphabetically (or at least 
 
 ### Plugin inspirations
 
-Credits to these plugin developers for pioneering functionality that were adapted into Obsidian:
+Credits to these ( plugin developers ) for pioneering functionality that were adapted into Obsidian:
+
 - pjeby for the Hotkey Helper plugin
 - javalent for the Admonition plugin
 - NothingIsLost for several CodeMirror 6 improvements
@@ -38,7 +42,7 @@ Credits to these plugin developers for pioneering functionality that were adapte
 - canzi-teacher, 蚕子 (Chinese Simplified)
 - Daniel Mathiot (French)
 - Henrik Falk (Danish)
-- JxhnnyUt8h (Russian) 
+- JxhnnyUt8h (Russian)
 - k-andzhanovskii, Константин Анджановский (Russian)
 - lisachev, Сергей Лисачев (Russian)
 - mafsi, (Patrick Danilevici) (Română)
@@ -55,7 +59,7 @@ The docs are currently maintained by [Marcus Olsson](https://marcus.se.net/).
 
 We now accept pull requests to the help vault in [our docs repo](https://github.com/obsidianmd/obsidian-docs/).
 
-##### Add your name
+#### Add your name
 
 If you're a translator, please make a pull request to add "Your Name (contributed language)" to the section above. Please keep the list of names alphabetical, thanks!
 
@@ -72,85 +76,106 @@ License: Attribution 3.0 Unported (CC BY 3.0)
 Obsidian uses the open source libraries below (in alphabetical order):
 
 #### Capacitor
+
 MIT License
 Copyright (c) 2017-present Drifty Co.
 
 #### CodeMirror
+
 MIT License
 Copyright (C) 2018 by Marijn Haverbeke <marijnh@gmail.com>, Adrian Heine <mail@adrianheine.de>, and others
 
 #### DOMPurify
+
 https://github.com/cure53/DOMPurify
 Licensed under the Mozilla Public License version 2.0
 http://mozilla.org/MPL/2.0/
 
 #### Electron
+
 MIT License
 Copyright (c) Electron contributors
 Copyright (c) 2013-2020 GitHub Inc.
 
 #### i18next
+
 The MIT License (MIT)
 Copyright (c) 2022 i18next
 
 #### Lezer
+
 MIT License
 Copyright (C) 2018-2021 by Marijn Haverbeke <marijnh@gmail.com> and others
 
 #### Lucide
+
 ISC License
 Copyright (c) 2020, Lucide Contributors
 
 #### MathJax
+
 Apache License 2.0
 
 #### Mermaid
+
 The MIT License (MIT)
 Copyright (c) 2014 - 2022 Knut Sveidqvist
 
 #### Moment.js
+
 MIT License
 Copyright (c) JS Foundation and other contributors
 
 #### nspell
+
 The MIT License
 Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>
 
 #### pdf.js
+
 Apache License 2.0
 
 #### PixiJS
+
 The MIT License
 Copyright (c) 2013-2017 Mathew Groves, Chad Engler
 
 #### Prism
+
 MIT LICENSE
 Copyright (c) 2012 Lea Verou
 
 #### rbush
+
 MIT License
 Copyright (c) 2016 Vladimir Agafonkin
 
 #### remark
+
 The MIT License
 Copyright (c) 2014-2020 Titus Wormer <tituswormer@gmail.com>
 Copyright (c) 2011-2014, Christopher Jeffrey (https://github.com/chjj/)
 
 #### reveal.js
+
 The MIT License
 Copyright (C) 2011-2022 Hakim El Hattab, http://hakim.se, and reveal.js contributors
 
 #### scrypt
+
 Apache License 2.0
 
 #### Turndown
+
 MIT License
 Copyright (c) 2017 Dom Christie
 
 #### Webpack
+
 MIT License
 Copyright JS Foundation and other contributors
 
 #### YAML
+
 ISC License
 Copyright Eemeli Aro <eemeli@gmail.com>


### PR DESCRIPTION
This PR adds the new team members to the Credit page.

I didn't know what tags they'd prefer, so maybe add a comment with your preferred tags :)

Fixes #365 