### PR TITLE
Add reference docs for keyboard shortcuts

### DIFF
--- a/en/Editing and formatting/Keyboard shortcuts for editing.md
+++ b/en/Editing and formatting/Keyboard shortcuts for editing.md
@@ -11,7 +11,7 @@ Learn how to use keyboard shortcuts to navigate and edit text in your notes.
 | Paste | `Ctrl+V` |
 | Paste without formatting | `Ctrl+Shift+V` |
 | Undo | `Ctrl+Z` |
-| Redo | `Ctrl+Shift+Z` |
+| Redo | `Ctrl+Shift+Z` or `Ctrl+Y` |
 | Copy paragraph | `Ctrl+C` (with no selected text) |
 | Cut paragraph | `Ctrl+X` (with no selected text) |
 

--- a/en/Editing and formatting/Keyboard shortcuts for editing.md
+++ b/en/Editing and formatting/Keyboard shortcuts for editing.md
@@ -26,6 +26,7 @@ Learn how to use keyboard shortcuts to navigate and edit text in your notes.
 | Delete the next word | `Ctrl+Delete` |
 | Delete to the beginning of the current line | `Ctrl+Backspace` |
 | Delete to the end of the current line | `Ctrl+Delete` |
+| Delete the current line | `Ctrl+Shift+K` (with no selected text) |
 
 ### Text navigation
 
@@ -47,6 +48,7 @@ Learn how to use keyboard shortcuts to navigate and edit text in your notes.
 
 | Action | Shortcut |
 |-|-|
+| Simplify selection | `Escape` |
 | Select all | `Ctrl+A` |
 | Extend selection one character | `Shift+Left/right arrow` |
 | Extend selection to the beginning of the previous word | `Ctrl+Shift+Left arrow` |
@@ -84,6 +86,7 @@ Learn how to use keyboard shortcuts to navigate and edit text in your notes.
 | Delete the next word | `Option+Delete` |
 | Delete to the beginning of the current line | `Cmd+Backspace` |
 | Delete to the end of the current line | `Cmd+Delete` |
+| Delete the current line | `Cmd+Shift+K` (with no selected text) |
 
 ### Text navigation
 
@@ -105,6 +108,7 @@ Learn how to use keyboard shortcuts to navigate and edit text in your notes.
 
 | Action | Shortcut |
 |-|-|
+| Simplify selection | `Escape` |
 | Select all | `Cmd+A` |
 | Extend selection one character | `Shift+Left/right arrow` |
 | Extend selection to the beginning of the previous word | `Option+Shift+Left arrow` |

--- a/en/Editing and formatting/Keyboard shortcuts for editing.md
+++ b/en/Editing and formatting/Keyboard shortcuts for editing.md
@@ -1,0 +1,113 @@
+Learn how to use keyboard shortcuts to navigate and edit text in your notes.
+
+## Windows and Linux shortcuts
+
+### Common actions
+
+| Action | Shortcut |
+|-|-|
+| Copy | `Ctrl+C` |
+| Cut | `Ctrl+X` |
+| Paste | `Ctrl+V` |
+| Paste without formatting | `Ctrl+Shift+V` |
+| Undo | `Ctrl+Z` |
+| Redo | `Ctrl+Shift+Z` |
+
+### Text editing
+
+| Action | Shortcut |
+|-|-|
+| Insert new line| `Enter` |
+| Delete the previous character | `Backspace` |
+| Delete the next character | `Delete` |
+| Delete the previous word | `Ctrl+Backspace` |
+| Delete the next word | `Ctrl+Delete` |
+| Delete to the beginning of the current line | `Ctrl+Backspace` |
+| Delete to the end of the current line | `Ctrl+Delete` |
+
+### Text navigation
+
+| Action | Shortcut |
+|-|-|
+| Move the cursor one character | `Left/right arrow` |
+| Move the cursor to the beginning of the previous word | `Ctrl+Left arrow` |
+| Move the cursor to the end of the next word | `Ctrl+Right arrow` |
+| Move the cursor to the beginning of the current line | `Home` |
+| Move the cursor to the end of the current line | `End` |
+| Move the cursor to the previous line | `Up arrow` |
+| Move the cursor to the next line | `Down arrow` |
+| Move the cursor to the beginning of the note | `Ctrl+Home` |
+| Move the cursor to the end of the note | `Ctrl+End` |
+| Move the cursor up one page | `Page up` |
+| Move the cursor down one page | `Page down` |
+
+### Text selection
+
+| Action | Shortcut |
+|-|-|
+| Select all | `Ctrl+A` |
+| Extend selection one character | `Shift+Left/right arrow` |
+| Extend selection to the beginning of the previous word | `Ctrl+Shift+Left arrow` |
+| Extend selection to the end of the next word | `Ctrl+Shift+Right arrow` |
+| Extend selection to the beginning of the current line | `Shift+Home` |
+| Extend selection to the end of the current line | `Shift+End` |
+| Extend selection to the beginning of the note | `Ctrl+Shift+Home` |
+| Extend selection to the end of the note | `Ctrl+Shift+End` |
+| Extend selection one page up | `Shift+Page up` |
+| Extend selection one page down | `Shift+Page down` |
+
+## macOS shortcuts
+
+### Common actions
+
+| Action | Shortcut |
+|-|-|
+| Copy | `Cmd+C` |
+| Cut | `Cmd+X` |
+| Paste | `Cmd+V` |
+| Paste without formatting | `Cmd+Shift+V` |
+| Undo | `Cmd+Z` |
+| Redo | `Cmd+Shift+Z` |
+
+### Text editing
+
+| Action | Shortcut |
+|-|-|
+| Insert new line| `Enter` |
+| Delete the previous character | `Backspace` |
+| Delete the next character | `Delete` |
+| Delete the previous word | `Option+Backspace` |
+| Delete the next word | `Option+Delete` |
+| Delete to the beginning of the current line | `Cmd+Backspace` |
+| Delete to the end of the current line | `Cmd+Delete` |
+
+### Text navigation
+
+| Action | Shortcut |
+|-|-|
+| Move the cursor one character | `Left/right arrow` |
+| Move the cursor to the beginning of the previous word | `Option+Left arrow` |
+| Move the cursor to the end of the next word | `Option+Right arrow` |
+| Move the cursor to the beginning of the current line | `Cmd+Left arrow` |
+| Move the cursor to the end of the current line | `Cmd+Right arrow` |
+| Move the cursor to the previous line | `Up arrow` |
+| Move the cursor to the next line | `Down arrow` |
+| Move the cursor to the beginning of the note | `Cmd+Up arrow` |
+| Move the cursor to the end of the note | `Cmd+Down arrow` |
+| Move the cursor up one page | `Ctrl+Up arrow` |
+| Move the cursor down one page | `Ctrl+Down arrow` |
+
+### Text selection
+
+| Action | Shortcut |
+|-|-|
+| Select all | `Cmd+A` |
+| Extend selection one character | `Shift+Left/right arrow` |
+| Extend selection to the beginning of the previous word | `Option+Shift+Left arrow` |
+| Extend selection to the end of the next word | `Option+Shift+Right arrow` |
+| Extend selection to the beginning of the current line | `Cmd+Shift+Left arrow` |
+| Extend selection to the end of the current line | `Cmd+Shift+Right arrow` |
+| Extend selection to the beginning of the note | `Cmd+Shift+Up arrow` |
+| Extend selection to the end of the note | `Cmd+Shift+Down arrow` |
+| Extend selection one page up | `Ctrl+Shift+Up arrow` |
+| Extend selection one page down | `Ctrl+Shift+Down arrow` |

--- a/en/Editing and formatting/Keyboard shortcuts for editing.md
+++ b/en/Editing and formatting/Keyboard shortcuts for editing.md
@@ -12,6 +12,8 @@ Learn how to use keyboard shortcuts to navigate and edit text in your notes.
 | Paste without formatting | `Ctrl+Shift+V` |
 | Undo | `Ctrl+Z` |
 | Redo | `Ctrl+Shift+Z` |
+| Copy paragraph | `Ctrl+C` (with no selected text) |
+| Cut paragraph | `Ctrl+X` (with no selected text) |
 
 ### Text editing
 
@@ -68,6 +70,8 @@ Learn how to use keyboard shortcuts to navigate and edit text in your notes.
 | Paste without formatting | `Cmd+Shift+V` |
 | Undo | `Cmd+Z` |
 | Redo | `Cmd+Shift+Z` |
+| Copy paragraph | `Cmd+C` (with no selected text) |
+| Cut paragraph | `Cmd+X` (with no selected text) |
 
 ### Text editing
 


### PR DESCRIPTION
This PR adds a new docs page for keyboard shortcuts in the editor in a new top-level folder called "Editing and formatting".

I named the note "Keyboard shortcuts for _editing_" to differentiate from hotkeys in search results.

The shortcuts are based on the standard keymap from CodeMirror 6:

https://codemirror.net/docs/ref/#commands.standardKeymap

Fixes #367 
Fixes #185 