### PR TITLE
Redirect refactored pages

### DIFF
--- a/en/Editing and formatting/Callouts.md
+++ b/en/Editing and formatting/Callouts.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- Use callouts
+- How to/Use callouts
 ---
 
 Use callouts to include additional content without breaking the flow of your notes.

--- a/en/Editing and formatting/HTML sanitization.md
+++ b/en/Editing and formatting/HTML sanitization.md
@@ -1,3 +1,8 @@
+---
+aliases:
+- Advanced topics/HTML sanitization
+---
+
 Obsidian supports HTML to allow you to display your notes the way you want, or even [[Embedding web pages|embed web pages]]. But allowing HTML inside your notes comes with risks. To prevent malicious code from doing harm, Obsidian _sanitizes_ any HTML in your notes.
 
 The Obsidian team takes security seriously, and as a result, some HTML elements or features may not be available.

--- a/en/Editing and formatting/Metadata.md
+++ b/en/Editing and formatting/Metadata.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - front matter
-  - YAML front matter
+  - Advanced topics/YAML front matter
 ---
 
 While most of the text in a note is meant to be read by a human, _metadata_ is text that's meant to be easily readable by a program, for example a [[Community plugins|community plugin]] or Obsidian itself.

--- a/en/Editing and formatting/Multiple cursors.md
+++ b/en/Editing and formatting/Multiple cursors.md
@@ -1,5 +1,6 @@
 ---
-alias: Working with multiple cursors
+aliases: 
+- How to/Working with multiple cursors
 ---
 
 Obsidian lets you edit text in multiple places at the same time using multiple cursors. You can add additional cursors by holding `Alt` (or `Option` on macOS) and selecting another position in the note.

--- a/en/Editing and formatting/Tags.md
+++ b/en/Editing and formatting/Tags.md
@@ -1,3 +1,8 @@
+---
+aliases: 
+- How to/Working with tags
+---
+
 Tags are keywords or topics that help you quickly find the notes you want.
 
 ## Add a tag to a note

--- a/en/Licenses and payment/Catalyst license.md
+++ b/en/Licenses and payment/Catalyst license.md
@@ -1,3 +1,8 @@
+---
+aliases:
+- Licenses & Payment/Catalyst license
+---
+
 While Obsidian is free of charge for personal use, you can support the Obsidian development by purchasing a _Catalyst_ license.
 
 While the Catalyst license doesn't grant you any additional features inside the app itself, you'll receive exclusive benefits, such as:

--- a/en/Licenses and payment/Commercial license.md
+++ b/en/Licenses and payment/Commercial license.md
@@ -1,3 +1,8 @@
+---
+aliases:
+- Licenses & Payment/Commercial license
+---
+
 If you're using Obsidian for commercial use in a company of two (2) or more employees, you need to purchase a Commercial license.
 
 Commercial use includes, but isn't limited to, work-related activities such as:

--- a/en/Licenses and payment/Education and non-profit discount.md
+++ b/en/Licenses and payment/Education and non-profit discount.md
@@ -1,5 +1,7 @@
 ---
-alias: "Student and non-profit discount"
+aliases: 
+- Student and non-profit discount
+- Licenses & Payment/Education and non-profit discount
 ---
 
 Obsidian currently offers two types of discounts: education and non-profit. They both give you 40% off our add-on services, including [[Introduction to Obsidian Sync|Obsidian Sync]] and [[Introduction to Obsidian Publish|Obsidian Publish]].

--- a/en/Licenses and payment/Gifting.md
+++ b/en/Licenses and payment/Gifting.md
@@ -1,3 +1,8 @@
+---
+aliases:
+- Licenses & Payment/Gifting
+---
+
 Although using Obsidian for personal use is completely free of charge, you can give the gift of Obsidian to someone to help them get an add-on service like [[Introduction to Obsidian Sync|Obsidian Sync]], or to get a [[Commercial license]] so they can use Obsidian for work.
 
 ## Give gift credits

--- a/en/Licenses and payment/Obsidian Credit.md
+++ b/en/Licenses and payment/Obsidian Credit.md
@@ -1,3 +1,8 @@
+---
+aliases:
+- Licenses & Payment/Obsidian Credit
+---
+
 Obsidian Credit is a type of prepaid credit. It can be bought in advance and applied towards purchases of all things Obsidian has to offer.
 
 Obsidian Credit will be applied before any payment is due, and it will also be applied at auto-renewals.

--- a/en/Licenses and payment/Refund policy.md
+++ b/en/Licenses and payment/Refund policy.md
@@ -1,3 +1,8 @@
+---
+aliases:
+- Licenses & Payment/Refund policy
+---
+
 We offer full refunds within 7 days of purchase with no questions asked for the following services and licenses:
 
 - [[Introduction to Obsidian Publish|Obsidian Publish]]

--- a/en/Linking notes and files/Aliases.md
+++ b/en/Linking notes and files/Aliases.md
@@ -1,5 +1,8 @@
 ---
-aliases: alias, aliases, Add aliases to note
+aliases: 
+- alias
+- aliases
+- How to/Add aliases to note
 ---
 
 If you want to reference a file using different names, consider adding _aliases_ to the note. An alias is an alternative name for a note.

--- a/en/Linking notes and files/Embedding files.md
+++ b/en/Linking notes and files/Embedding files.md
@@ -1,5 +1,6 @@
 ---
-alias: Embed files
+aliases: 
+- How to/Embed files
 ---
 
 Learn how you can embed other notes and media into your notes. By embedding files in your notes, you can reuse content across your vault.

--- a/en/Linking notes and files/Internal links.md
+++ b/en/Linking notes and files/Internal links.md
@@ -1,5 +1,7 @@
 ---
-aliases: Internal link, Link to blocks
+aliases: 
+- How to/Internal link
+- How to/Link to blocks
 ---
 
 Learn how to link to notes, attachments, and other files from your notes, using _internal links_. By linking notes, you can create a network of knowledge. ^b15695

--- a/en/Plugins/Backlinks.md
+++ b/en/Plugins/Backlinks.md
@@ -1,5 +1,6 @@
 ---
-alias: Working with backlinks
+aliases: 
+- How to/Working with backlinks
 ---
 
 With the Backlinks plugin, you can see all the _backlinks_ for the active note.


### PR DESCRIPTION
To use aliases to redirect previously existing pages, we need to use the full path.

Fixes #401 