### PR TITLE
Editing and previewing Markdown

### DIFF
--- a/en/Editing and formatting/Editing and previewing Markdown.md
+++ b/en/Editing and formatting/Editing and previewing Markdown.md
@@ -1,0 +1,40 @@
+---
+alias: How to/Read and edit modes
+---
+
+Obsidian lets you customize how to edit and preview notes with Markdown syntax using _editor views_ and _editor modes_.
+
+Markdown is a markup language that uses special syntax to format text that's mainly useful when editing your notes. Less so when reading them. Instead, Obsidian can convert them into a format that's more suitable for reading.
+
+Editor views and modes lets you customize how Markdown syntax appears when you're editing and reading notes.
+
+## Editor views
+
+You can switch between the _Editing view_ a _Reading view_, depending on whether you intend to make changes to the note.
+
+To switch between views, select the view switcher (open book icon or pencil icon) in the upper-right corner of the editor, or press `Ctrl+E` (or `Cmd+E` on macOS) in the editor.
+
+You can change the default editor view under **Settings** -> **Editor** -> **Default view for new tabs**.
+
+> [!tip] Side-by-side preview
+> To open a note in both editing and reading view side-by-side, press `Ctrl` (or `Cmd` on macOS) and select the view switcher (open book icon or pencil icon) in the upper-right corner of the editor.
+
+## Editor modes
+
+In Editing view, you can edit your notes using one of two modes, _Live Preview_ or _Source mode_.
+
+You can change the default editor mode under **Settings** -> **Editor** -> **Default editing mode**.
+
+### Live Preview
+
+Live Preview is a smart editor mode that previews Markdown-formatted text while you're editing.
+
+Since Live Preview lets you see the formatted in the Editing view, you often don't need to switch between editor views. 
+
+You can reveal the syntax for any Markdown-formatted text by moving the text cursor to it.
+
+### Source mode
+
+Source mode displays the Markdown syntax for the entire note. 
+
+Use Source mode if you prefer to see the plain text representation of the note.

--- a/en/Editing and formatting/Editing and previewing Markdown.md
+++ b/en/Editing and formatting/Editing and previewing Markdown.md
@@ -4,15 +4,18 @@ alias: How to/Read and edit modes
 
 Obsidian lets you customize how to edit and preview notes with Markdown syntax using _editor views_ and _editor modes_.
 
-Markdown is a markup language that uses special syntax to format text that's mainly useful when editing your notes. Less so when reading them. Instead, Obsidian can convert them into a format that's more suitable for reading.
+Markdown is a markup language that uses special syntax to format text that's mainly useful when editing your notes. Less so when reading them. Instead, Obsidian can show them in a way that's more suitable for reading.
 
 Editor views and modes lets you customize how Markdown syntax appears when you're editing and reading notes.
 
 ## Editor views
 
-You can switch between the _Editing view_ a _Reading view_, depending on whether you intend to make changes to the note.
+You can switch between the _editing view_ and _reading view_, depending on whether you intend to make changes to the note.
 
 To switch between views, select the view switcher (open book icon or pencil icon) in the upper-right corner of the editor, or press `Ctrl+E` (or `Cmd+E` on macOS) in the editor.
+
+> [!note]
+> You need to enable **Settings** -> **Appearance** -> **Show tab title bar** to see the icon for switching views.
 
 You can change the default editor view under **Settings** -> **Editor** -> **Default view for new tabs**.
 
@@ -29,12 +32,13 @@ You can change the default editor mode under **Settings** -> **Editor** -> **Def
 
 Live Preview is a smart editor mode that previews Markdown-formatted text while you're editing.
 
-Since Live Preview lets you see the formatted in the Editing view, you often don't need to switch between editor views. 
-
 You can reveal the syntax for any Markdown-formatted text by moving the text cursor to it.
+
+> [!tip]
+> Since Live Preview lets you see the formatted in the editing view, it often removes the need to switch between editor views.
 
 ### Source mode
 
-Source mode displays the Markdown syntax for the entire note. 
+Source mode displays the Markdown syntax for the entire note.
 
 Use Source mode if you prefer to see the plain text representation of the note.

--- a/en/Editing and formatting/Metadata.md
+++ b/en/Editing and formatting/Metadata.md
@@ -22,7 +22,7 @@ Today I learned about front matter.
 ```
 
 > [!tip]
-> By default, metadata is only visible in the [[Read and edit modes|editing view]].
+> By default, metadata is only visible in the [[Editing and previewing Markdown#Editor views|editing view]].
 >
 > To display metadata in reading view:
 >

--- a/en/User interface/Workspace/Panes/Linked pane.md
+++ b/en/User interface/Workspace/Panes/Linked pane.md
@@ -1,6 +1,6 @@
 Panes can be linked together. This has two main effects:
 
-- By default, when opening a new [[Read and edit modes|reading pane]] from an editing pane, the new pane is linked to the old one. This means that any changes you make in the editor will show up in the reading pane in real time. It also means that scrolling one will scroll the other.
+- By default, when opening a new [[Editing and previewing Markdown#Editor views|reading view]] from an editing view, the new pane is linked to the old one. This means that any changes you make in the editor will show up in the reading pane in real time. It also means that scrolling one will scroll the other.
 
 - When a new [[Backlinks#Open a linked backlinks pane|Backlink Pane]] is created from a note, it will be linked to that note. This means that [[backlinks]] will always be shown for the note that is in that pane. This is useful if you want to reference a set of [[backlinks]] but let the regular backlink panel change with whatever other note you are working on.
 


### PR DESCRIPTION
This PR deprecates How to/Read and edit modes in favor of a new page that documents both editor views and editor modes.