### PR TITLE
Incorrect linking to advanced guide & core plugins

### DIFF
--- a/en/Obsidian/Index.md
+++ b/en/Obsidian/Index.md
@@ -39,11 +39,11 @@ To read more about the makers, see the [about page](https://obsidian.md/about) o
 
 ### Official plugins
 
-![[Core plugins#Current list of official plugins]]
+![[Core plugins#Current list of core plugins]]
 
 ### Advanced guides
 
 - [[Working with multiple notes]]
-- [[Pane layout]]
+- [[Use tabs in Obsidian]]
 - [[Working with multiple vaults]]
 - [[Using Obsidian URI]]


### PR DESCRIPTION
Noticed that Pane Layout guide isn't linking to any pages, seems to link to using tabs in obsidian online, so updated it to that. The embedded link to core plugins was incorrectly(?) trying to link to official plugins, which doesn't exist. Not sure if core plugins is wrong and should be updated in that page, or if the link has the wrong name.