### PR TITLE
Web Clipper: Add a note that `map` function cannot use the built-in filters

### DIFF
--- a/en/Obsidian Web Clipper/Filters.md
+++ b/en/Obsidian Web Clipper/Filters.md
@@ -301,6 +301,8 @@ String literals are supported and automatically wrapped in an object with a `str
 
 Combine `map` with the `template` filter, e.g. `map:item => ({name: ${item.gem}, color: item.color})|template:"- ${name} is ${color}\n"`.
 
+Note: Built-in filters cannot be used inside `map`. This means that, for example, trimming each value of an array cannot be done with `map`.
+
 ### `merge`
 
 Adds new values to an array.


### PR DESCRIPTION
For example, you can't do the equivalent of the following pseudocode: `array.map {arrItem -> trim(arrItem) }`

References:
- https://discord.com/channels/686053708261228577/1285652864089198672/1415974235427442770
- https://discord.com/channels/686053708261228577/1285652864089198672/1286679863939301567