### PR TITLE
Fix browse themes instructions

### DIFF
--- a/en/Extending Obsidian/Themes.md
+++ b/en/Extending Obsidian/Themes.md
@@ -9,7 +9,7 @@ Learn how to change the look and feel of Obsidian using themes built by the comm
 ## Browse themes
 
 1. Open **Settings**.
-2. Select **Browse** to list all available community themes.
+2. Under **Appearance → Themes**, select **Manage** to list all available community themes.
 
 ## Install a new theme
 


### PR DESCRIPTION
Alternatively the entire "Browse themes" section could be dropped, for now it doesn't really add significant information next to the install section, right?