### PR TITLE
Add an example for a simple filter

### DIFF
--- a/en/Bases/Bases syntax.md
+++ b/en/Bases/Bases syntax.md
@@ -66,7 +66,9 @@ By default a base includes every file in the vault. There is no `from` or `sourc
 
 ```yaml
 # Simple filter:
-filters: file.hasTag("tag")
+filters:
+  and:
+    - file.hasTag("tag")
 
 # Complex filter:
 filters:


### PR DESCRIPTION
Thank you for your work on the product and on the Bases feature that fits exactly a use case I've been struggling with.

The current documentation wasn't enough for an AI coding assistant to create a working example of a very simple filter. The proposed (failing) solution was:

```
filters: 
  - file.hasTag("tag")
```

Should this work? Didn't for me (version 1.10.6).