### PR TITLE
Clarify allowed tag characters including Unicode and emojis

### DIFF
--- a/en/Editing and formatting/Tags.md
+++ b/en/Editing and formatting/Tags.md
@@ -46,10 +46,7 @@ You can use any of the following characters in your tags:
 - Underscore (`_`)
 - Hyphen (`-`)
 - Forward slash (`/`) for [[#Nested tags]]
-- Unicode characters, including emojis and other symbols
-
-> [!note] 
-> While older documentation listed only letters, numbers, `_`, `-`, and `/`, Obsidian also allows emojis and other Unicode characters in tags.
+- Commonly accepted Unicode characters, including emojis and other symbols
 
 Tags must contain at least one non-numerical character. For example, #1984 isn't a valid tag, but #y1984 is.
 


### PR DESCRIPTION
This PR updates the tag documentation to reflect that Obsidian allows Unicode characters, including emojis, in tags, even though older docs specify only letters, numbers, underscore (_), hyphen (-), and forward slash (/).

Fixes #1015