### PR TITLE
Obsidian CLI: Moved early access warning to top of page

### DIFF
--- a/en/Extending Obsidian/Obsidian CLI.md
+++ b/en/Extending Obsidian/Obsidian CLI.md
@@ -2,14 +2,14 @@
 permalink: cli
 description: Anything you can do in Obsidian can be done from the command line.
 ---
+> [!warning] Early access feature
+> Obsidian CLI requires Obsidian 1.12 or above, which is currently an [[Early access versions|early access version]] and requires a [[Catalyst license]]. Commands and syntax are likely to change during the early access phase.
+
 Obsidian CLI is a command line interface that lets you control Obsidian from your terminal for scripting, automation, and integration with external tools.
 
 Anything you can do in Obsidian can be done from the command line. Obsidian CLI even includes [[#Developer commands|developer commands]] to access developer tools, inspect elements, take screenshots, reload plugins, and more.
 
 ![[obsidian-cli.mp4#interface]]
-
-> [!warning] Early access feature
-> Obsidian CLI requires Obsidian 1.12 or above, which is currently an [[Early access versions|early access version]] and requires a [[Catalyst license]]. Commands and syntax are likely to change during the early access phase.
 
 ## Install Obsidian CLI
 


### PR DESCRIPTION
By moving the warning that the Obsidian CLI is an early access feature to the top of the page, it is the first thing people read in the article, making it clearer that this is upcoming. Its current position below a big video makes it easy to miss it on desktop and on mobile it's barely visible.

<img width="270" height="630" alt="Mobile screenshot of the corresponding help page, only the top of the warning callout is visible at the bottom of the page" src="https://github.com/user-attachments/assets/b02b5b88-55d4-41e5-8fac-65ddeb33f7da" />

(edit: reduced dimensions of image)
