### PR TITLE
Templates: Add more information on commands (#1013) and insertion behaviour

### DIFF
--- a/en/Plugins/Templates.md
+++ b/en/Plugins/Templates.md
@@ -31,7 +31,7 @@ To set a format string, add a colon (`:`) followed by a string of [Moment.js for
 
 You can use `{{date}}` and `{{time}}` interchangeably with format strings, for example `{{time:YYYY-MM-DD}}`.
 
-You can change the default date and time formats under **[[Settings]] → Templates → Date format** and **[[Settings]] → Templates → Time format**.
+You can change the default date and time formats under **[[Settings]] → Templates → Date format** and **[[Settings]] → Templates → Time format**. ^template-settings-date-time-formatting
 
 > [!tip]
 > You can also use the `{{date}}` and `{{time}}` template variables in the [[Daily notes]] and [[Unique note creator]] plugins.
@@ -79,6 +79,16 @@ tags:
 1. In the ribbon, click **Insert template**.
 2. Select the template to insert at the cursor position in the active note.
 
-## Template properties
+To insert a template using the [[Command palette]] or [[Hotkeys#Set a hotkey|a custom keyboard shortcut]], use the command `Templates: Insert template`.
+
+The content of the template is inserted at your current cursor position. If your cursor is not in the note body, the content is inserted at your last cursor position.
+
+### Template properties
 
 ![[Properties#^templates-properties]]
+
+## Inserting current date and time into the active note
+
+Use the commands `Templates: Insert current date` and `Templates: Insert current time` to insert the current date and time at your current cursor position. Like the `Insert template` command this can be done with the [[Command palette]] or [[Hotkeys#Set a hotkey|a custom keyboard shortcut]].
+
+The inserted date and time uses the [[#^template-settings-date-time-formatting|formatting set in the plugin settings]].


### PR DESCRIPTION
## 1. Adding information on the plugin's commands 

As mentioned in #1013, it would be useful to include information on the plugin's command as an alternative to using the Ribbon and as a way for inserting the current date or time. (edit: expanded this paragraph)

## 2. Adding information on the insertion behaviour

my thought was that it'd be good to know that the template content is inserted at the current/last cursor position (tested this in sandbox vault).

## Notes 

I'm aware that I have linked to [[Command palette]] and [[Hotkeys]] which could be considered [over-linking](https://help.obsidian.md/style-guide#Cross-references). My thought here was users don't necessarily read the entire page top-down, particularly when they use the Publish search or outline to go directly to that paragraph. I can change that if desired.

I'm not sure if block identifiers work with Publish, but in case they work I thought including a link to the formatting setting would be good to direct users to the correct place. Without that they'd first have to search through the article to find that specific piece of information.
