### PR TITLE
Fix broken link

### DIFF
--- a/en/Extending Obsidian/Obsidian URI.md
+++ b/en/Extending Obsidian/Obsidian URI.md
@@ -105,7 +105,7 @@ The `daily` action accepts the same parameters as the `new` action.
 
 ## Unique Note
 
-The `unique` action creates a new unique note in the vault. The [[en/Plugins/Unique note creator|Unique note creator]] plugin must be enabled.
+The `unique` action creates a new unique note in the vault. The [[Plugins/Unique note creator|Unique note creator]] plugin must be enabled.
 
 ### Examples
 


### PR DESCRIPTION
This link to the Unique note creator plugin had the wrong relative path (incorrect `en/` prefix)