### PR TITLE
Update .red-border img example (CSS snippets.md)

### DIFF
--- a/en/Extending Obsidian/CSS snippets.md
+++ b/en/Extending Obsidian/CSS snippets.md
@@ -69,6 +69,7 @@ It has a host of [CSS variables](https://docs.obsidian.md/Reference/CSS+variable
 > ```css
 > .red-border img {
 >    border-color: #ff0000;
+>    border-style: solid;
 > }
 > ```
 > 


### PR DESCRIPTION
`.red-border img { border-color: #ff0000; }` alone won't show the border. `border-style` is required.