### PR TITLE
Fix stale and mis-scoped internal doc links

### DIFF
--- a/en/Editing and formatting/Properties.md
+++ b/en/Editing and formatting/Properties.md
@@ -287,7 +287,7 @@ The following default properties can be used with [[Introduction to Obsidian Pub
 
 | Property      | Description                                                                                                |
 | ------------- | ---------------------------------------------------------------------------------------------------------- |
-| `publish`     | See [[Publish your content#Automatically select notes to publish\|Automatically select notes to publish]]. |
+| `publish`     | See [[Publish your content#Automatically select data to publish\|Automatically select data to publish]]. |
 | `permalink`   | See [[Permalinks\|Permalinks]].                                                                            |
 | `description` | See [[Social media link previews#Description\|Description]].                                               |
 | `image`       | See [[Social media link previews#Image\|Image]].                                                           |

--- a/en/Obsidian Publish/SEO.md
+++ b/en/Obsidian Publish/SEO.md
@@ -29,7 +29,7 @@ Page metadata can be customized using [[Properties#Properties for Obsidian Publi
 
 | Property      | Description                                                                                                       |
 | ------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `publish`     | See [[Publish your content#Automatically select notes to publish\|Automatically select notes to publish]]. |
+| `publish`     | See [[Publish your content#Automatically select data to publish\|Automatically select data to publish]]. |
 | `permalink`   | See [[Permalinks\|Permalinks]].                                                                                   |
 | `description` | See [[Social media link previews#Description\|Description]].                                                      |
 | `image`       | See [[Social media link previews#Image\|Image]].                                                                  |

--- a/en/Obsidian Sync/Set up Obsidian Sync.md
+++ b/en/Obsidian Sync/Set up Obsidian Sync.md
@@ -48,7 +48,7 @@ In this section, you'll create a new [[Local and remote vaults|remote vault]] an
 3. Next to **Remote vault**, select **Choose**.
 4. Select **Create new vault**.
 5. In **Vault name**, enter the name of the remote vault.
-6. In **Region**, choose your server [[#Regional sync servers|region]] for your remote vault. 
+6. In **Region**, choose your server [[Set up Obsidian Sync#Regional sync servers|region]] for your remote vault. 
 7. In **Encryption password**, choose a password for your vault. This creates an end-to-end encrypted vault. The vault password is separate from your Obsidian account and can be different for each of your vaults. For more information, refer to [[Security and privacy]].
 8. Select **Create**.
 

--- a/en/Obsidian Sync/Sync regions.md
+++ b/en/Obsidian Sync/Sync regions.md
@@ -29,8 +29,8 @@ To change your remote vault's region, you will need to recreate your vault on a 
 
 ![[Set up Obsidian Sync#Disconnect from a remote vault]]
 
-If you are on the [[Plans and storage limits|Standard Plan]], you will also need to [[#Delete a remote vault|delete your remote vault]] before proceeding.
+If you are on the [[Plans and storage limits|Standard Plan]], you will also need to [[Set up Obsidian Sync#Delete a remote vault|delete your remote vault]] before proceeding.
 
 ![[Set up Obsidian Sync#Create a new remote vault]]
 
-Additionally, you can [[#Delete a remote vault|delete your old remote vault]] once you have confirmed transition to your new remote vault and its region.
+Additionally, you can [[Set up Obsidian Sync#Delete a remote vault|delete your old remote vault]] once you have confirmed transition to your new remote vault and its region.

--- a/en/Obsidian Sync/Upgrade Sync encryption.md
+++ b/en/Obsidian Sync/Upgrade Sync encryption.md
@@ -39,6 +39,6 @@ Before you proceed, create a [[Back up your Obsidian files|backup]] of your vaul
 3. Click **Upgrade vault**. This option will only be visible if an upgrade is available for your remote vault.
 4. Double check your backups and click **Continue**.
 5. In **Vault name**, enter the name of the remote vault.
-6. In **Region**, choose your server [[#Regional sync servers|region]] for your remote vault. 
+6. In **Region**, choose your server [[Set up Obsidian Sync#Regional sync servers|region]] for your remote vault. 
 7. In **Encryption password**, choose a password for your vault. This creates an end-to-end encrypted vault. The vault password is separate from your Obsidian account and can be different for each of your vaults. For more information, refer to [[Security and privacy]].
 8. Once you re-upload your data with the new encryption, re-connect to the new Sync vault on your other devices.

--- a/en/Obsidian Web Clipper/Variables.md
+++ b/en/Obsidian Web Clipper/Variables.md
@@ -89,7 +89,7 @@ The syntax is `{{selector:cssSelector?attribute}}`, where `?attribute` is option
 - Nested CSS selectors and combinators are supported if you need more specificity.
 - If multiple elements match the selector, an array is returned, which you can process with [[Filters#Arrays and objects|array and object filters]] like `join` or `map`.
 
-Selector variables can also be used directly in [[Templates#Template logic|template logic]]:
+Selector variables can also be used directly in [[Logic|template logic]]:
 
 - In loops: `{% for comment in selector:.comment %}...{% endfor %}`
 - In conditionals: `{% if selector:.premium-badge %}...{% endif %}`

--- a/en/Plugins/Command palette.md
+++ b/en/Plugins/Command palette.md
@@ -20,7 +20,7 @@ As of **version 1.8.3**, recently used commands appear at the top of the Command
 You can pin frequently used commands at the top of the Command palette to quickly access them without having to type their name.
 
 > [!tip] Tip
-> If you want to quickly run frequently used commands, you can also [[Hotkeys#Setting hotkeys|set hotkeys]] for them.
+> If you want to quickly run frequently used commands, you can also [[Hotkeys#Set a hotkey|set hotkeys]] for them.
 
 ### Pin a command
 

--- a/en/Plugins/Daily notes.md
+++ b/en/Plugins/Daily notes.md
@@ -8,7 +8,7 @@ To open today's daily note, either:
 
 - Click **Open today's daily note** ( ![[lucide-calendar.svg#icon]] ) in the [[Ribbon|ribbon]].
 - Run **Open today's daily note** from the [[Command palette]].
-- [[Hotkeys#Setting hotkeys|Use a hotkey]] for the **Open today's daily note** command.
+- [[Hotkeys#Set a hotkey|Use a hotkey]] for the **Open today's daily note** command.
 
 By default, Obsidian creates a new empty note named after today's date in the YYYY-MM-DD format.
 

--- a/en/Teams/Deploy Obsidian across your team.md
+++ b/en/Teams/Deploy Obsidian across your team.md
@@ -23,7 +23,7 @@ For security-related questions concerning these topics, please refer to [[Securi
 
 ### Configuration folders
 
-The [[Configuration folder]] is where an Obsidian [[Glossary#Vault|vault]] stores its application settings. By default, this folder is named `.obsidian`, but you have the flexibility to [[Configuration folder#Changing your configuration folder|change the configuration folder]] name according to your preference.
+The [[Configuration folder]] is where an Obsidian [[Glossary#Vault|vault]] stores its application settings. By default, this folder is named `.obsidian`, but you have the flexibility to [[Configuration folder#Change your configuration folder|change the configuration folder]] name according to your preference.
 
 We recommend creating a standardized template of the configuration folder to be deployed across your team's devices.
 


### PR DESCRIPTION
This PR fixes a set of broken internal links caused by renamed headings, outdated anchor text, and links pointing to the wrong page.

Corrected links:
- Updated links to the Obsidian Publish section from "Automatically select notes to publish" to the current "Automatically select data to publish" heading.
- Updated links to the Hotkeys section from "Setting hotkeys" to the current "Set a hotkey" heading.
- Updated the Configuration folder link from "Changing your configuration folder" to the current "Change your configuration folder" heading.
- Fixed links in Sync regions that incorrectly used a local "Delete a remote vault" anchor, and pointed them to the correct section in Set up Obsidian Sync.
- Fixed the link in Upgrade Sync encryption that incorrectly used a local "Regional sync servers" anchor, and pointed it to the correct section in Set up Obsidian Sync.
- Updated the Web Clipper Variables link that pointed to "Templates#Template logic" after that content was moved/reorganized.

Pages affected:
- Editing and formatting/Properties
- Obsidian Publish/SEO
- Plugins/Command palette
- Plugins/Daily notes
- Teams/Deploy Obsidian across your team
- Obsidian Sync/Sync regions
- Obsidian Sync/Upgrade Sync encryption
- Obsidian Web Clipper/Variables

Result:
- Removes stale anchor references
- Fixes links that were scoped to the wrong page
- Brings cross-references in line with current heading names and document structure