### PR TITLE
docs: update plugin security docs for new community directory

### DIFF
--- a/en/Extending Obsidian/Community plugins.md
+++ b/en/Extending Obsidian/Community plugins.md
@@ -18,7 +18,7 @@ Learn how to extend Obsidian with plugins built by the community. Use plugins to
 
 Use the text box to filter plugins based on their name, author, and description.
 
-You can also browse available plugins in your browser, by heading to [obsidian.md/plugins](https://obsidian.md/plugins).
+You can also browse available plugins in your browser, by heading to [community.obsidian.md](https://community.obsidian.md).
 
 ## Install a community plugin
 

--- a/en/Extending Obsidian/Plugin security.md
+++ b/en/Extending Obsidian/Plugin security.md
@@ -34,11 +34,9 @@ Due to technical limitations, Obsidian cannot reliably restrict plugins to speci
 
 ## Plugin review process
 
-Community plugins undergo an initial review when they're submitted to the plugin store. All plugins must adhere to [Obsidian Developer Policies](https://docs.obsidian.md/Developer+policies).
+All community plugins must adhere to [Obsidian Developer Policies](https://docs.obsidian.md/Developer+policies). Obsidian automatically scans every plugin version for security vulnerabilities, code quality issues, and malware. Each plugin's page in the [plugin directory](https://community.obsidian.md) displays the results as a safety scorecard.
 
-The Obsidian team is small and unable to manually review every new release of community plugins. Instead, we rely on the help of the community to identify and report issues with plugins.
+Manual reviews continue for popular, featured, and flagged plugins.
 
-- If you discover any minor security vulnerabilities in a community plugin, refer to the plugin author's `security.md` or `readme.md` for how to report those. For Critical category flaws, please report the issue to [[Help and support#Contact Obsidian support|Obsidian support]] as well. 
-- If you suspect that a community plugin is malicious, report it to [[Help and support#Contact Obsidian support|Obsidian support]], or by sending a DM to our moderators.
-
-
+- If you discover a security vulnerability in a community plugin, refer to the plugin author's `security.md` or `readme.md` for how to report it. For critical flaws, also report the issue to [[Help and support#Contact Obsidian support|Obsidian support]].
+- If you suspect that a community plugin is malicious, you can flag it directly from its plugin directory page, report it to [[Help and support#Contact Obsidian support|Obsidian support]], or send a DM to our moderators.

--- a/en/Teams/Security considerations for teams.md
+++ b/en/Teams/Security considerations for teams.md
@@ -15,7 +15,7 @@ If you do not intend to use community plugins or themes, or [[Introduction to Ob
 
 Please review the [[Plugin security]] page in addition to this section. 
 
-The Obsidian teams reviews all community plugins and themes submitted to the official directory, via our [releases repository](https://github.com/obsidianmd/obsidian-releases/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc). We do not review community items which have not been submitted to the official directory.
+Obsidian automatically scans every version of a community plugin or theme in the [official directory](https://obsidian.md/plugins) for security vulnerabilities, code quality issues, and malware. Each project's directory page displays the results as a safety scorecard. Manual reviews continue for popular, featured, and flagged items. We do not review community items which have not been submitted to the official directory.
 
 We do not have a community store for [[CSS snippets]]. These files are typically obtained from within our [Obsidian Community](https://obsidian.md/community) or from public GitHub repositories.
 
@@ -41,7 +41,7 @@ The following is a list of network connections Obsidian makes.
 
 ### GitHub-sourced connections
 
-Obsidian makes network requests to both `github.com` and `raw.githubusercontent.com`.
+Obsidian makes network requests to both `github.com` and `raw.githubusercontent.com`.
 
 - **Public releases**: If automatic updates are enabled, Obsidian checks GitHub for public releases.
 - **Third-party themes and plugins**:


### PR DESCRIPTION
Updates plugin pages with new community directory links, and some added details from the https://obsidian.md/blog/future-of-plugins/ post. More to come as we add more. 
