### PR TITLE
docs: clarify fallback template usage in Web Clipper

### DIFF
--- a/en/Obsidian Web Clipper/Templates.md
+++ b/en/Obsidian Web Clipper/Templates.md
@@ -65,4 +65,4 @@ Schema.org values can also be used to [[Variables#Schema.org variables|pre-popul
 
 ### Interpreter context
 
-When [[Interpreter|Interpreter]] is enabled, you can use [[Variables#Prompt variables|prompt variables]] to extract page content with natural language. For each template you can define the [[Interpreter#Context|context]] that Interpreter has access too. 
+When [[Interpreter|Interpreter]] is enabled, you can use [[Variables#Prompt variables|prompt variables]] to extract page content with natural language. For each template you can define the [[Interpreter#Context|context]] that Interpreter has access to. 

--- a/en/Obsidian Web Clipper/Templates.md
+++ b/en/Obsidian Web Clipper/Templates.md
@@ -36,7 +36,7 @@ Define how content from Web Clipper will be added to Obsidian:
 
 Template triggers allow you to automatically select a template based on the current page URL or [schema.org](https://schema.org/) data. You can define multiple rules for each template, separated by a new line.
 
-The first match in your template list determines which template is used. You can drag templates up and down in Web Clipper settings to change the order in which templates are matched.
+The first match in your template list determines which template is used. You can drag templates up and down in Web Clipper settings to change the order in which templates are matched. To ensure the correct fallback template is used for everyday clipping, keep the default template at the top.
 
 #### Simple URL matching
 

--- a/en/Obsidian Web Clipper/Templates.md
+++ b/en/Obsidian Web Clipper/Templates.md
@@ -36,7 +36,10 @@ Define how content from Web Clipper will be added to Obsidian:
 
 Template triggers allow you to automatically select a template based on the current page URL or [schema.org](https://schema.org/) data. You can define multiple rules for each template, separated by a new line.
 
-The first match in your template list determines which template is used. You can drag templates up and down in Web Clipper settings to change the order in which templates are matched. To ensure the correct fallback template is used for everyday clipping, keep the default template at the top.
+The first match in your template list determines which template is used. You can drag templates up and down in Web Clipper settings to change the order in which templates are matched.
+
+> [!tip]- Set a fallback template
+> If a page doesn't match any trigger rule, Web Clipper uses the first template in your list. Keep the template you want as your fallback at the top of the list to ensure it's used for pages without a specific match.
 
 #### Simple URL matching
 


### PR DESCRIPTION
Added a note about keeping the default template at the top for fallback. I tested with v1.6.1 on Firefox 151.0b10 (64-bit), and Google Chrome Version 148.0.7778.168 (Official Build) (64-bit). If the default is not at the top, the first template is used.