### PR TITLE
docs(cli): note that auto-launch does not apply on WSL2

### DIFF
--- a/en/Extending Obsidian/Obsidian CLI.md
+++ b/en/Extending Obsidian/Obsidian CLI.md
@@ -30,6 +30,8 @@ Obsidian CLI supports both single commands and a terminal user interface (TUI) w
 > [!info] Obsidian app must be running
 > Obsidian CLI requires the Obsidian app to be running. If Obsidian is not running, the first command you run launches Obsidian.
 >
+> Note: this auto-launch behavior does not apply on WSL2 (Windows Subsystem for Linux). See [[#WSL2]] below.
+>
 > Looking to sync without the desktop app? See [[Obsidian Headless|Obsidian Headless]].
 
 ### Run a command
@@ -1530,5 +1532,15 @@ If the binary is missing, copy it manually from the Obsidian installation direct
 cp /path/to/Obsidian/obsidian-cli ~/.local/bin/obsidian
 chmod 755 ~/.local/bin/obsidian
 ```
+
+#### WSL2
+
+On WSL2 (Windows Subsystem for Linux), the CLI does not auto-launch the Obsidian GUI. Invoking the CLI when the app is not running returns:
+
+```
+The CLI is unable to find Obsidian. Please make sure Obsidian is running and try again.
+```
+
+Start the Obsidian app separately (via the WSLg-published `.desktop` Start Menu entry or by running the GUI binary directly from a terminal), then run CLI commands.
 
 


### PR DESCRIPTION
## What

Adds a WSL2-specific note to the **Get started** auto-launch sentence and a new `#### WSL2 (Windows Subsystem for Linux)` subsection inside the existing `### Linux` troubleshooting block. No existing text is removed; the auto-launch claim is preserved verbatim and only annotated with a forward reference to the new subsection.

## Why

While running Obsidian on WSL2, the documented behavior

> If Obsidian is not running, the first command you run launches Obsidian.

does not occur. Invoking the CLI from a terminal when the GUI is not running returns the error:

> The CLI is unable to find Obsidian. Please make sure Obsidian is running and try again.

Investigation:

- The CLI binary installed at `~/.local/bin/obsidian` by the in-app "Command line interface" toggle is small (~67 KB ELF, aarch64). Running `strings` on it reveals only the unix-socket-related literals (`XDG_RUNTIME_DIR`, `%s/.obsidian-cli.sock`) and the error message above — no PATH lookups for a GUI binary, no `.desktop` discovery, no AppImage scanning. The binary appears to be CLI-socket-only.
- `wsl --shutdown`, `wsl --update`, and a full Windows reboot did not change the behavior — it is reproducible on every cold launch.
- Behavior is confirmed to differ from macOS, where the CLI's auto-launch path uses a symlink into the application bundle.

## Scope

This PR only documents the WSL2 case, because that is the only environment in which the failure was reproduced. The wording is intentionally not generalized to "Linux" — desktop Linux installs via deb/rpm/snap may behave differently and were not tested.

## Reproduce

1. Install Obsidian 1.12.7 ARM64 AppImage on WSL2 (Ubuntu 24.04 aarch64, WSLg active) by extracting via `--appimage-extract`.
2. Toggle Settings → General → "Command line interface" ON.
3. Close the Obsidian GUI.
4. From a terminal (in a vault directory), run `obsidian`.

Expected per docs: GUI launches.
Actual: prints "The CLI is unable to find Obsidian. Please make sure Obsidian is running and try again." and exits.

## Files changed

- `en/Extending Obsidian/Obsidian CLI.md` — two additive edits described above.
