### PR TITLE
docs: clarify internal link folder paths

### DIFF
--- a/en/Linking notes and files/Internal links.md
+++ b/en/Linking notes and files/Internal links.md
@@ -25,6 +25,10 @@ Obsidian supports the following link formats:
 
 The examples above are equivalent, and they appear the same way in the editor and links to the same note.
 
+To link to a note in a folder, include the folder path before the note name. Folder paths start at the vault root and use forward slashes (`/`), even on Windows: `[[Projects/Three laws of motion]]` or `[Three laws of motion](Projects/Three%20laws%20of%20motion.md)`.
+
+If the link points to a note that doesn't exist yet, Obsidian creates the note at that folder path instead of using your [[Settings#Default location for new notes|default location for new notes]].
+
 > [!note] Note
 > When using the Markdown format, make sure to [URL encode](https://en.wikipedia.org/wiki/Percent-encoding) the link destination. For example, blank spaces become `%20`.
 

--- a/en/User interface/Settings.md
+++ b/en/User interface/Settings.md
@@ -190,6 +190,8 @@ Where newly created notes are placed. Options include:
 - **Same folder as current file** — Notes are created in the same folder as the currently active note.
 - **In the folder specified below** — Notes are created in a specific folder you choose.
 
+This setting doesn't apply when an [[Internal links|internal link]] includes a folder path. For example, creating `[[Projects/Three laws of motion]]` creates the note in the `Projects` folder relative to the vault root.
+
 ### Default location for new attachments
 
 Where newly added [[Attachments|attachments]] are placed. Options include:


### PR DESCRIPTION
## Summary

Clarifies how folder paths work in internal links:

- folder paths in links start at the vault root
- folder paths use forward slashes, including on Windows
- links that include a folder path create missing notes at that path instead of using the default new-note location

Closes #1082.

## Validation

- `git diff --check`
- `PATH="$PWD/scripts/node_modules/.bin:$PATH" npx tsx scripts/check-links.ts en` — no broken wikilinks
- `PATH="$PWD/scripts/node_modules/.bin:$PATH" npx tsx scripts/check-terms.ts en` — 0 issues
