### PR TITLE
docs: align Bases formula examples with runtime

### DIFF
--- a/en/Bases/Bases syntax.md
+++ b/en/Bases/Bases syntax.md
@@ -290,7 +290,7 @@ The global [[Functions|function]] `today()` can be used to get the current date,
 - `now() + "1 day"` returns a datetime exactly 24 hours from the time of execution.
 - `file.mtime > now() - "1 week"` returns `true` if the file was modified within the last week.
 - `date("2024-12-01") + "1M" + "4h" + "3m"` returns a Date object representing `2025-01-01 04:03:00`.
-- Subtract two dates to get the millisecond difference between the two, for example, `now() - file.ctime`.
+- Subtract two dates to get a duration, for example, `note.release_date - today()`.
 - To get the date portion of a Date with time, use `datetime.date()`.
 - To format a Date object, use the `format()` function, for example `datetime.format("YYYY-MM-DD")`.
 

--- a/en/Bases/Functions.md
+++ b/en/Bases/Functions.md
@@ -150,7 +150,7 @@ Functions you can use with any value. This includes strings (e.g. `"hello"`), nu
 `any.isTruthy(): boolean`
 
 - Returns the value coerced into a boolean.
-- Example: `1.isTruthy()` returns `true`.
+- Example: `(1).isTruthy()` returns `true`.
 
 ### `isType()`
 
@@ -164,7 +164,7 @@ Functions you can use with any value. This includes strings (e.g. `"hello"`), nu
 `any.toString(): string`
 
 - Returns the string representation of any value.
-- Example: `123.toString()` returns `"123"`.
+- Example: `(123).toString()` returns `"123"`.
 
 ## Date type
 
@@ -371,7 +371,7 @@ Functions you can use with numeric values such as `42`, `3.14`.
 `number.isEmpty(): boolean`
 
 - Returns true if the number is not present.
-- Example: `5.isEmpty()` returns `false`.
+- Example: `(5).isEmpty()` returns `false`.
 
 ### `round()`
 
@@ -586,14 +586,14 @@ The following fields are available for files:
 
 ## Object type
 
-Functions you can use with a collection of key-value pairs such as `{"a": 1, "b": 2}`.
+Functions you can use with object values such as `file.properties`, which contain a collection of key-value pairs.
 
 ### `isEmpty()`
 
 `object.isEmpty(): boolean`
 
 - Returns true if the object has no own properties.
-- Example: `{}.isEmpty()` returns `true`.
+- Example: `file.properties.isEmpty()` returns `true` if the file has no properties.
 
 ### `keys()`
 


### PR DESCRIPTION
## Summary

- Updates date subtraction docs to describe the duration value returned by current Bases formulas.
- Uses parenthesized numeric literals in method-call examples so the examples match parser behavior.
- Describes object methods using `file.properties` instead of object literal examples.

Fixes #1095

## Validation

- `npx tsx scripts/check-links.ts en`
- `npx tsx scripts/check-terms.ts en`
- `(cd scripts && npx tsc --noEmit)`
- `git diff --check origin/master...HEAD`
