### PR TITLE
docs: expand Sync illegal name guidance

### DIFF
--- a/en/Obsidian Sync/Status icon and messages.md
+++ b/en/Obsidian Sync/Status icon and messages.md
@@ -86,9 +86,13 @@ These are messages detailing what was skipped, and potentially why.
 
 **Unable to download file with illegal name**
 
-The file contains a [special character or naming convention](https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names) that is not allowed on the receiving operating system. For ease, you can rename the file on it's source device to remove all special characters but `-` and `_`.
+The file name uses a [special character or naming convention](https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names) that the receiving operating system cannot store. Rename the file on its source device, then let Sync upload the renamed file again.
 
-Note that this also includes files with multiple periods `.` in their name on Android devices. 
+For vaults synced across different operating systems, avoid characters that are commonly reserved by file systems, such as `/`, `\`, `:`, `*`, `?`, `"`, `<`, `>`, and `|`. Names can also cause problems when they end with a space or period, or use Windows reserved device names such as `CON`, `PRN`, `AUX`, `NUL`, `COM1` through `COM9`, or `LPT1` through `LPT9`. For link-friendly note names, also avoid characters Obsidian uses for links, such as `#`, `^`, `[`, and `]`.
+
+On Android, files with multiple periods `.` in their name can also be skipped. Some Android devices may also reject emoji in file names.
+
+When in doubt, use letters, numbers, regular spaces inside the name, hyphens `-`, underscores `_`, and one period before the file extension.
 
 ### Account messages
 

--- a/en/Obsidian Sync/Status icon and messages.md
+++ b/en/Obsidian Sync/Status icon and messages.md
@@ -88,9 +88,13 @@ These are messages detailing what was skipped, and potentially why.
 
 The file name uses a [special character or naming convention](https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names) that the receiving operating system cannot store. Rename the file on its source device, then let Sync upload the renamed file again.
 
-For vaults synced across different operating systems, avoid characters that are commonly reserved by file systems, such as `/`, `\`, `:`, `*`, `?`, `"`, `<`, `>`, and `|`. Names can also cause problems when they end with a space or period, or use Windows reserved device names such as `CON`, `PRN`, `AUX`, `NUL`, `COM1` through `COM9`, or `LPT1` through `LPT9`. For link-friendly note names, also avoid characters Obsidian uses for links, such as `#`, `^`, `[`, and `]`.
+For vaults synced across different operating systems, avoid the following in file and folder names:
 
-On Android, files with multiple periods `.` in their name can also be skipped. Some Android devices may also reject emoji in file names.
+- Characters commonly reserved by file systems, such as `/`, `\`, `:`, `*`, `?`, `"`, `<`, `>`, and `|`
+- A space or period at the end of the name
+- Windows reserved device names, such as `CON`, `PRN`, `AUX`, `NUL`, `COM1` through `COM9`, or `LPT1` through `LPT9`
+- Characters Obsidian uses for links, such as `#`, `^`, `[`, and `]`, if you want link-friendly note names
+- Multiple periods `.` in a file name, or emoji, both of which some Android devices may reject
 
 When in doubt, use letters, numbers, regular spaces inside the name, hyphens `-`, underscores `_`, and one period before the file extension.
 


### PR DESCRIPTION
Fixes #1001

## Summary
- expand the Sync skipped-message entry for illegal file names
- replace the broad "remove all special characters" guidance with concrete cross-platform examples
- include Android and link-friendly filename notes from the issue discussion

## Validation
- git diff --check
- npm --prefix scripts install --no-package-lock
- scripts/node_modules/.bin/tsx scripts/check-links.ts en
- scripts/node_modules/.bin/tsx scripts/check-terms.ts en