### PR TITLE
docs: mention downgrading early access versions

### DIFF
--- a/en/Obsidian/Early access versions.md
+++ b/en/Obsidian/Early access versions.md
@@ -48,7 +48,7 @@ When you report an issue, include the build version and the OS you're running it
 
 ## Switch back to public versions on desktop
 
-To switch back to using public versions (not early access) on desktop:
+To downgrade from an early access version to the latest public version on desktop:
 
 1. Disable early access versions.
    1. Open **[[Settings]]**.
@@ -63,7 +63,7 @@ To switch back to using public versions (not early access) on desktop:
 
 ## Switch back to public versions on mobile
 
-To switch back to using public versions (not early access) on mobile:
+To downgrade from an early access version to the latest public version on mobile:
 
 1. Back up your vault data
 2. Uninstall Obsidian

--- a/en/Obsidian/Early access versions.md
+++ b/en/Obsidian/Early access versions.md
@@ -48,7 +48,7 @@ When you report an issue, include the build version and the OS you're running it
 
 ## Switch back to public versions on desktop
 
-To downgrade from an early access version to the latest public version on desktop:
+To disable early access versions and revert to your last installed public version on desktop:
 
 1. Disable early access versions.
    1. Open **[[Settings]]**.
@@ -60,6 +60,7 @@ To downgrade from an early access version to the latest public version on deskto
    - Mac: `~/Library/Application Support/obsidian/obsidian-VERSION.asar`
    - Linux: `~/.config/obsidian/obsidian-VERSION.asar`
 4. Restart Obsidian.
+5. If Obsidian isn't on the latest public version afterward, update the [[Update Obsidian#Installer updates|installer version]].
 
 ## Switch back to public versions on mobile
 


### PR DESCRIPTION
## Summary

Fixes #1053.

Adds natural "downgrade" wording to the existing early access rollback instructions so users searching for how to downgrade from an early access build can find the documented public-version steps.

## Validation

- `git diff --check origin/master...HEAD`
- `scripts/node_modules/.bin/tsx scripts/check-links.ts en`
- `scripts/node_modules/.bin/tsx scripts/check-terms.ts en`
- `codex review --base origin/master`