### PR TITLE
Document combined PDF embed options

### DIFF
--- a/en/Linking notes and files/Embed files.md
+++ b/en/Linking notes and files/Embed files.md
@@ -91,6 +91,12 @@ You can also specify the height in pixels for the embedded PDF viewer by adding 
 ![[Document.pdf#height=400]]
 ```
 
+To combine page and height options, separate them with `&`:
+
+```md
+![[Document.pdf#page=3&height=400]]
+```
+
 ## Embed a canvas in a note
 
 To embed a [[Canvas|canvas]]:


### PR DESCRIPTION
## Summary

- Add an example showing how to combine PDF `page` and `height` embed options with `&`.

## Context

Closes #1000.

## Verification

- Confirmed the Markdown code fence count remains even.
- Ran `git diff --check`.
