### PR TITLE
Update Electron version to 43.1.1 in credits

### DIFF
--- a/en/Obsidian/Credits.md
+++ b/en/Obsidian/Credits.md
@@ -145,7 +145,7 @@ Licensed under the [Mozilla Public License version 2.0](http://mozilla.org/MPL/2
 
 ### Electron
 
-Version `37.3.0`
+Version `43.1.1`
 MIT License
 Copyright (c) Electron contributors
 Copyright (c) 2013-2020 GitHub Inc.


### PR DESCRIPTION
Bump the Electron version listed in Third party acknowledgements to 43.1.1, matching today's public release

