### PR TITLE
Improve Japanese callout documentation

### DIFF
--- a/ja/編集と書式設定/コールアウト.md
+++ b/ja/編集と書式設定/コールアウト.md
@@ -88,9 +88,9 @@ description: このページでは、ノートの流れを中断せずに追加�
 }
 ```
 
-`data-callout` 属性の値は使用したいタイプ識別子です。例えば `[!custom-question-type]` のように指定します。
+`data-callout` 属性には、使用するコールアウトタイプの識別子を指定します。例えば、`[!custom-question-type]` のように指定します。
 
-- `--callout-color` は背景色を定義します。有効な CSS カラーであればどれでも使用できます。例えば16進コード（`#000000`）や `rgb()` 値などです。
+- `--callout-color` は背景色を定義します。有効な CSS カラーであればどれでも使用できます。例えば、16進コード（`#000000`）や `rgb()` 値などです。
 - `--callout-icon` には [lucide.dev](https://lucide.dev) のアイコン ID、または SVG 要素を指定できます。
 
 > [!warning] lucide アイコンバージョンに関する注意
@@ -105,9 +105,9 @@ description: このページでは、ノートの流れを中断せずに追加�
 > ```
 
 > [!tip]- さらなるカスタマイズ
-> `--callout-color` と `--callout-icon` だけに限りません。コールアウトは標準的な CSS セレクターやプロパティに加え、ボーダーやタイトルのスタイリングなどの追加 CSS 変数もサポートしています。
+> `--callout-color` と `--callout-icon` 以外もカスタマイズできます。コールアウトでは、標準の CSS セレクターやプロパティに加えて、枠線やタイトルのスタイルを設定する CSS 変数も使用できます。
 > 
-> 例えば、コールアウトのタイトルを非表示にするには：
+> 例えば、コールアウトのタイトルを非表示にするには、次の CSS を使用します。
 > 
 > ```css
 > .callout[data-callout="custom-question-type"] .callout-title {
@@ -115,7 +115,7 @@ description: このページでは、ノートの流れを中断せずに追加�
 > }
 > ```
 > 
-> またはボーダーを調整するには：
+> 枠線を調整するには、次の CSS を使用します。
 > 
 > ```css
 > .callout[data-callout="custom-question-type"] {
@@ -124,7 +124,7 @@ description: このページでは、ノートの流れを中断せずに追加�
 > }
 > ```
 > 
-> その他のオプションについては、[コールアウト CSS 変数](https://docs.obsidian.md/Reference/CSS+variables/Editor/Callout)の全リストを参照してください。
+> その他のオプションについては、[コールアウト CSS 変数](https://docs.obsidian.md/Reference/CSS+variables/Editor/Callout)の一覧を参照してください。
 
 ### サポートされるタイプ
 


### PR DESCRIPTION
## What changed

- Refined six machine-translated phrases in the Japanese Callouts documentation.
- Replaced literal or awkward wording with more natural Japanese.
- Preserved the original meaning, CSS examples, links, and document structure.

## Why

The recently synchronized Japanese text was understandable but contained several literal expressions, including redundant wording and English-style punctuation. This update improves readability for Japanese users without changing the documented behavior.

## Validation

- `scripts/node_modules/.bin/tsx scripts/check-links.ts ja`
- `scripts/node_modules/.bin/tsx scripts/check-terms.ts ja`
- `scripts/node_modules/.bin/tsx scripts/sync-locale.ts ja --dry-run`
- `git diff --check`

All checks passed. The locale sync dry run reported 171 unchanged files and no structural changes.
