### PR TITLE
Add Flatpak mimeapps.list troubleshooting help for Web Clipper

### DIFF
--- a/en/Obsidian Web Clipper/Troubleshoot Web Clipper.md
+++ b/en/Obsidian Web Clipper/Troubleshoot Web Clipper.md
@@ -31,6 +31,7 @@ If you don't see any content in Obsidian when you click **Add to Obsidian**:
 
 - Make sure the [[Obsidian URI]] protocol [[Obsidian URI#Register Obsidian URI|is registered]].
 - If you are using Firefox you may need to [register it the browser settings](https://kb.mozillazine.org/Register_protocol).
+- If you are using the Flatpak, you may need to update the `x-scheme-handler/obsidian` value found in your `.config/mimeapps.list` from `obsidian.desktop` to `md.obsidian.Obsidian.desktop`.
 
 #### Obsidian opens but only the file name is saved
 

--- a/es/Obsidian Web Clipper/Solución de problemas de Web Clipper.md
+++ b/es/Obsidian Web Clipper/Solución de problemas de Web Clipper.md
@@ -31,6 +31,7 @@ Si no ves ningún contenido en Obsidian cuando haces clic en **Añadir a Obsidia
 
 - Asegúrate de que el protocolo [[Obsidian URI]] [[Obsidian URI#Registrar el URI de Obsidian|esté registrado]].
 - Si usas Firefox puede que necesites [registrarlo en los ajustes del navegador](https://kb.mozillazine.org/Register_protocol).
+- Si usas Flatpak, puede que necesites actualizar el valor de `x-scheme-handler/obsidian` que se encuentra en tu `.config/mimeapps.list` de `obsidian.desktop` a `md.obsidian.Obsidian.desktop`.
 
 #### Obsidian se abre pero solo se guarda el nombre del archivo
 


### PR DESCRIPTION
Adds troubleshooting consideration for Flatpak users to the Troubleshoot Web Clipper page. The Flatpak `.desktop` file name does not match the default value of `obsidian.desktop`. Meaning the Web Clipper is unable to launch the Flatpak unless the `mimeapps.list` file is updated.

Related issue: https://github.com/obsidianmd/obsidian-help/issues/1120