### PR TITLE
harden: sanitize child_process call in apply-diff-locale.ts...

### DIFF
--- a/scripts/apply-diff-locale.ts
+++ b/scripts/apply-diff-locale.ts
@@ -18,7 +18,7 @@
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
-import { execSync } from "child_process";
+import { execSync, spawnSync } from "child_process";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const SCRIPTS_DIR = import.meta.dirname;
@@ -178,11 +178,11 @@ function getGitDiff(): string {
 
 function getOldEnContent(enRelPath: string): string | null {
   const ref = fromRef ?? "HEAD";
-  try {
-    return execSync(`git show "${ref}:en/${enRelPath}"`, { cwd: ROOT, encoding: "utf8" });
-  } catch {
+  const result = spawnSync("git", ["show", `${ref}:en/${enRelPath}`], { cwd: ROOT, encoding: "utf8" });
+  if (result.status !== 0) {
     return null; // file didn't exist at that ref (new file — handled by sync-locale)
   }
+  return result.stdout;
 }
 
 // ─── Git diff parsing ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Harden input handling in `scripts/apply-diff-locale.ts` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `scripts/apply-diff-locale.ts:182` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `enRelPath`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Changes
- `scripts/apply-diff-locale.ts`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
